### PR TITLE
Partially implement challenges section

### DIFF
--- a/load_sample_data.py
+++ b/load_sample_data.py
@@ -10,7 +10,6 @@ django.setup()
 
 from talent.models import Person, Skill, Expertise, PersonSkill
 from commerce.utils import CurrencyTypes, PaymentTypes
-from security.models import User
 from commerce.services import (
     OrganisationService,
     OrganisationAccountService,
@@ -18,7 +17,6 @@ from commerce.services import (
     CartService,
     PointPriceConfigurationService,
 )
-from security.services import UserService
 from talent.services import PersonService
 
 
@@ -57,7 +55,6 @@ else:
         "OrganisationAccountCredit": "commerce",
         "Cart": "commerce",
         "Person": "talent",
-        "User": "security",
         "Person": "talent",
     }
 
@@ -87,6 +84,7 @@ else:
             "password": "123456789",
             "headline": "Lorem ipsum sit amet",
             "overview": "Test test test",
+            "is_test_user": True,
         },
         {
             "first_name": "Shirley",
@@ -96,6 +94,7 @@ else:
             "password": "123456789",
             "headline": "Lorem ipsum sit amet",
             "overview": "Test test test",
+            "is_test_user": True,
         },
     ]
 

--- a/load_sample_data.py
+++ b/load_sample_data.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import django
+from random import choice, sample, randint
 from django.apps import apps
 import json
 from utility.utils import *
@@ -8,8 +9,6 @@ from utility.utils import *
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openunited.settings")
 django.setup()
 
-from talent.models import Person, Skill, Expertise, PersonSkill
-from commerce.utils import CurrencyTypes, PaymentTypes
 from commerce.services import (
     OrganisationService,
     OrganisationAccountService,
@@ -17,7 +16,14 @@ from commerce.services import (
     CartService,
     PointPriceConfigurationService,
 )
-from talent.services import PersonService
+from product_management.models import Capability
+from talent.services import PersonService, SkillService, ExpertiseService
+from product_management.services import (
+    InitiativeService,
+    TagService,
+    ProductService,
+    ChallengeService,
+)
 
 
 def load_reference_data(classname):
@@ -37,6 +43,41 @@ def clear_rows_by_model_name(model_names_mapping: dict) -> None:
         model.objects.all().delete()
 
 
+def create_capabilities():
+    fancy_out("Create Capability records")
+    get = lambda node_id: Capability.objects.get(pk=node_id)
+    root = Capability.add_root(
+        name="Capability 1", description="Description of Capability 1"
+    )
+    node = get(root.pk).add_child(
+        name="Capability 2", description="Description of Capability 2"
+    )
+    get(node.pk).add_sibling(
+        name="Capability 3", description="Description of Capability 3"
+    )
+    get(node.pk).add_sibling(
+        name="Capability 4", description="Description of Capability 4"
+    )
+    get(node.pk).add_child(
+        name="Capability 5", description="Description of Capability 5"
+    )
+    get(node.pk).add_child(
+        name="Capability 6", description="Description of Capability 6"
+    )
+    get(node.pk).add_child(
+        name="Capability 7", description="Description of Capability 7"
+    )
+
+    return Capability.objects.all()
+
+
+def read_json_data(file_name, model_name=None):
+    if model_name:
+        fancy_out(f"Create {model_name.title()} records")
+    with open(file_name, "r") as json_file:
+        return json.load(json_file)
+
+
 proceed = input(
     "Running this script will replace all your current data. Ok? (Y/N)"
 ).lower()
@@ -49,111 +90,98 @@ if proceed[0] != "y":
     fancy_out("Stopped at your request")
     exit()
 else:
-    d = {
-        "Organisation": "commerce",
-        "OrganisationAccount": "commerce",
-        "OrganisationAccountCredit": "commerce",
-        "Cart": "commerce",
-        "Person": "talent",
-        "Person": "talent",
-    }
+    model_app_mapping = read_json_data("sample_data/model_app_mapping.json")
 
-    print(f"Delete all the records of the following models: {d.keys()}")
+    print(f"Delete all the records of the following models: {model_app_mapping.keys()}")
     # Deletes all the existing records before populating sample data according to the dictionary
-    clear_rows_by_model_name(d)
+    clear_rows_by_model_name(model_app_mapping)
 
-    fancy_out("Create Person records")
-
-    person_data = [
-        {
-            "first_name": "Doğukan",
-            "last_name": "Teber",
-            "email": "dogukan@example.com",
-            "username": "dogukan",
-            "password": "dogukan",
-            "headline": "Super lorem ipsum sit amet",
-            "overview": "Super user",
-            "is_staff": True,
-            "is_superuser": True,
-        },
-        {
-            "first_name": "Gary",
-            "last_name": "Test",
-            "email": "test+gary@openunited.com",
-            "username": "garyg",
-            "password": "123456789",
-            "headline": "Lorem ipsum sit amet",
-            "overview": "Test test test",
-            "is_test_user": True,
-        },
-        {
-            "first_name": "Shirley",
-            "last_name": "Test",
-            "email": "test+shirley@openunited.com",
-            "username": "shirleyaghost",
-            "password": "123456789",
-            "headline": "Lorem ipsum sit amet",
-            "overview": "Test test test",
-            "is_test_user": True,
-        },
-    ]
+    person_data = read_json_data("sample_data/person.json", "person")
 
     people = []
     for pd in person_data:
         people.append(PersonService.create(**pd))
 
-    # Temporarily commented-out
+    product_data = read_json_data("sample_data/product.json", "product")
 
-    # fancy_out("Setup Skills & Expertise records")
+    products = []
+    for pd in product_data:
+        products.append(ProductService.create(**pd))
 
-    # load_reference_data("skill")
-    # load_reference_data("expertise")
+    initiative_data = read_json_data("sample_data/initiative.json", "initiative")
 
-    # fancy_out("Create PersonSkill records")
+    for elem in initiative_data:
+        elem["product"] = choice(products)
 
-    # # Skill: Full-stack Development
-    # full_stack_development = Skill.objects.get(pk=106)
+    initiatives = []
+    for i_data in initiative_data:
+        initiatives.append(InitiativeService.create(**i_data))
 
-    # # Expertise: Django
-    # django_expertise = Expertise.objects.get(pk=33)
+    capabilities = create_capabilities()
 
-    # gary_skill = PersonSkill(
-    #     person=gary,
-    #     skill=full_stack_development.ancestry(),
-    #     expertise=django_expertise.ancestry(),
-    # )
-    # gary_skill.save()
+    skill_data = read_json_data("sample_data/skill.json", "skill")
 
-    fancy_out("Create Organisation records")
+    skills = []
+    for sk in skill_data:
+        skills.append(SkillService.create(**sk))
 
-    usernames = [
-        "organisation_1",
-        "organisation_2",
-        "organisation_3",
-        "organisation_4",
-        "organisation_5",
-    ]
+    expertise_data = read_json_data("sample_data/expertise.json", "expertise")
+
+    expertise = []
+    for exp in expertise_data:
+        expertise.append(ExpertiseService.create(**exp))
+
+    tag_data = read_json_data("sample_data/tag.json", "tag")
+
+    tags = []
+    for tag in tag_data:
+        tags.append(TagService.create(**tag))
+
+    challenge_data = read_json_data("sample_data/challenge.json", "challenge")
+
+    for elem in challenge_data:
+        elem["initiative"] = choice(initiatives)
+        elem["capability"] = choice(capabilities)
+        elem["created_by"] = choice(people)
+        elem["updated_by"] = choice(people)
+        elem["reviewer"] = choice(people)
+        elem["product"] = choice(products)
+        elem["skill"] = choice(skills)
+
+    challenges = []
+    for cd in challenge_data:
+        challenge = ChallengeService.create(**cd)
+        challenge.expertise.set(sample(expertise, k=randint(1, 3)))
+        challenges.append(challenge)
+
+    organisation_data = read_json_data("sample_data/organisation.json", "organisation")
+
     organisations = []
-    organisation_service = OrganisationService()
-    for username in usernames:
-        organisations.append(organisation_service.create(username, username))
+    for org_data in organisation_data:
+        organisations.append(OrganisationService.create(**org_data))
 
-    fancy_out("Create OrganisationAccount records")
+    organisation_account_data = read_json_data(
+        "sample_data/organisation_account.json", "organisation account"
+    )
+
+    for index, oad in enumerate(organisation_account_data):
+        oad["organisation"] = organisations[index]
 
     organisation_accounts = []
-    organisation_account_service = OrganisationAccountService()
-    for organisation in organisations:
-        # TODO: replace the below 0's with random numbers
-        organisation_accounts.append(
-            organisation_account_service.create(organisation, 0, 0)
-        )
+    for oad in organisation_account_data:
+        organisation_accounts.append(OrganisationAccountService.create(**oad))
+
+    organisation_account_credit_data = read_json_data(
+        "sample_data/organisation_account_credit.json", "organisation account credit"
+    )
+
+    for index, oac in enumerate(organisation_account_credit_data):
+        oac["organisation_account"] = organisation_accounts[index]
 
     organisation_account_credits = []
-    organisation_account_credit_service = OrganisationAccountCreditService()
-    for organisation_account in organisation_accounts:
-        # TODO: replace the below 0 with a random number
+    for oacd in organisation_account_credit_data:
         organisation_account_credits.append(
-            organisation_account_credit_service.create(organisation_account, 0)
+            OrganisationAccountCreditService.create(**oacd)
         )
 
     fancy_out("Create a PointPriceConfiguration record")
@@ -169,44 +197,14 @@ else:
         gbp_point_outbound_price_in_cents=1,
     )
 
-    # Temporarily commented out
+    cart_data = read_json_data("sample_data/cart.json", "cart")
 
-    # fancy_out("Create Cart records")
+    for index, cd in enumerate(cart_data):
+        cd["creator"] = choice(people)
+        cd["organisation_account"] = organisation_accounts[index]
 
-    # carts = []
-    # cart_service = CartService()
-    # for index, organisation_account in enumerate(organisation_accounts):
-    #     if index == 0:
-    #         person_index = 0
-    #     else:
-    #         person_index = index % len(persons)
-
-    #     cart = cart_service.create(
-    #         organisation_account,
-    #         persons[person_index],
-    #         0,  # TODO: replace 0 with something meaningful
-    #         CurrencyTypes.EUR,
-    #         PaymentTypes.ONLINE,
-    #     )
-
-    #     carts.append(cart)
-
-    # fancy_out("Create Product records")
-
-    # fancy_out("Create ProductRole records")
-
-    # fancy_out("Create Capability records")
-
-    # fancy_out("Create Challenge records")
-
-    # fancy_out("Create Challenge Dependency records")
-
-    # fancy_out("Create Bounty records")
-
-    # fancy_out("Create BountyClaim records")
-
-    # fancy_out("Create BountyClaim Submission Attempt records")
-
-    # fancy_out("Create Portfolio records")
+    carts = []
+    for cd in cart_data:
+        carts.append(CartService.create(**cd))
 
     fancy_out("Complete!")

--- a/openunited/jinja2.py
+++ b/openunited/jinja2.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import  # Python 2 only
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.urls import reverse
+
+from jinja2 import Environment
+
+
+def environment(**options):
+    env = Environment(**options)
+    env.globals.update(
+        {
+            "static": staticfiles_storage.url,
+            "url": reverse,
+        }
+    )
+    return env

--- a/openunited/settings.py
+++ b/openunited/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "engagement",
     "commerce",
     "django_extensions",
+    "django_jinja",
 ]
 
 MIDDLEWARE = [
@@ -62,6 +63,38 @@ ROOT_URLCONF = "openunited.urls"
 
 
 TEMPLATES = [
+    {
+        "BACKEND": "django_jinja.backend.Jinja2",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "environment": "openunited.jinja2.environment",
+            "match_extension": ".html",
+            "match_regex": r"^(?!admin/).*",
+            # Can be set to "jinja2.Undefined" or any other subclass.
+            "newstyle_gettext": True,
+            "extensions": [
+                "jinja2.ext.do",
+                "jinja2.ext.loopcontrols",
+                "jinja2.ext.i18n",
+                "django_jinja.builtins.extensions.CsrfExtension",
+                "django_jinja.builtins.extensions.CacheExtension",
+                "django_jinja.builtins.extensions.DebugExtension",
+                "django_jinja.builtins.extensions.TimezoneExtension",
+                "django_jinja.builtins.extensions.UrlsExtension",
+                "django_jinja.builtins.extensions.StaticFilesExtension",
+                "django_jinja.builtins.extensions.DjangoFiltersExtension",
+            ],
+            "bytecode_cache": {
+                "name": "default",
+                "backend": "django_jinja.cache.BytecodeCache",
+                "enabled": False,
+            },
+            "autoescape": True,
+            "auto_reload": DEBUG,
+            "translation_engine": "django.utils.translation",
+        },
+    },
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [os.path.join(BASE_DIR, "templates")],

--- a/openunited/urls.py
+++ b/openunited/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", views.home, name="home"),
     path("talent/", include("talent.urls")),
+    path("", include("product_management.urls")),
 ]

--- a/product_management/models.py
+++ b/product_management/models.py
@@ -20,17 +20,21 @@ class Tag(TimeStampMixin):
     def __str__(self):
         return self.name
 
+
 class Capability(MP_Node):
     name = models.CharField(max_length=255)
-    description = models.TextField(max_length=1000, default='')
+    description = models.TextField(max_length=1000, default="")
     video_link = models.CharField(max_length=255, blank=True, null=True)
-    comments_start = models.ForeignKey(to='talent.capabilitycomment',
-                                       on_delete=models.SET_NULL,
-                                       null=True, editable=False)
+    comments_start = models.ForeignKey(
+        to="talent.capabilitycomment",
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+    )
 
     class Meta:
-        db_table = 'capability'
-        verbose_name_plural = 'capabilities'
+        db_table = "capability"
+        verbose_name_plural = "capabilities"
 
     def __str__(self):
         return self.name
@@ -40,7 +44,9 @@ class Capability(MP_Node):
 def save_capability(sender, instance, created, **kwargs):
     if not created:
         # update challengelisting when capability info is updated
-        ChallengeListing.objects.filter(capability=instance).update(capability_data=to_dict(instance))
+        ChallengeListing.objects.filter(capability=instance).update(
+            capability_data=to_dict(instance)
+        )
 
 
 class Attachment(models.Model):
@@ -49,7 +55,7 @@ class Attachment(models.Model):
     file_type = models.CharField(max_length=5, null=True, blank=True)
 
     class Meta:
-        ordering = ['name']
+        ordering = ["name"]
 
     def __str__(self):
         return self.name
@@ -60,16 +66,24 @@ class CapabilityAttachment(models.Model):
     attachment = models.ForeignKey(Attachment, on_delete=models.CASCADE)
 
     class Meta:
-        db_table = 'capability_attachment'
+        db_table = "capability_attachment"
 
 
 class Product(ProductMixin):
-    attachment = models.ManyToManyField(Attachment, related_name="product_attachments", blank=True)
-    capability_start = models.ForeignKey(Capability, on_delete=models.CASCADE, null=True, editable=False)
-    owner = models.ForeignKey('security.ProductOwner', on_delete=models.CASCADE, null=True)
+    attachment = models.ManyToManyField(
+        Attachment, related_name="product_attachments", blank=True
+    )
+    capability_start = models.ForeignKey(
+        Capability, on_delete=models.CASCADE, null=True, editable=False
+    )
+    owner = models.ForeignKey(
+        "security.ProductOwner", on_delete=models.CASCADE, null=True
+    )
 
     def get_members_emails(self):
-        return self.productrole_set.all().values_list("person__email_address", flat=True)
+        return self.productrole_set.all().values_list(
+            "person__email_address", flat=True
+        )
 
     def get_members_ids(self):
         return self.productrole_set.all().values_list("person__id", flat=True)
@@ -79,7 +93,11 @@ class Product(ProductMixin):
 
     def get_product_owner(self):
         product_owner = self.owner
-        return product_owner.organisation if product_owner.organisation else product_owner.person.user
+        return (
+            product_owner.organisation
+            if product_owner.organisation
+            else product_owner.person.user
+        )
 
     def __str__(self):
         return self.name
@@ -93,9 +111,10 @@ def save_product(sender, instance, created, **kwargs):
             product_data=dict(
                 name=instance.name,
                 slug=instance.slug,
-                owner=instance.get_product_owner().username
+                owner=instance.get_product_owner().username,
             )
         )
+
 
 class ProductRole(TimeStampMixin, UUIDMixin):
     FOLLOWER = 0
@@ -110,21 +129,26 @@ class ProductRole(TimeStampMixin, UUIDMixin):
         (CONTRIBUTOR, "Contributor"),
     )
     person = models.ForeignKey(Person, on_delete=models.CASCADE)
-    product = models.ForeignKey('product_management.Product', on_delete=models.CASCADE)
+    product = models.ForeignKey("product_management.Product", on_delete=models.CASCADE)
     role = models.IntegerField(choices=RIGHTS, default=0)
 
     def __str__(self):
-        return '{} is {} of {}'.format(self.person.user.username, self.get_right_display(), self.product)
+        return "{} is {} of {}".format(
+            self.person.user.username, self.get_right_display(), self.product
+        )
+
 
 class Initiative(TimeStampMixin, UUIDMixin):
     INITIATIVE_STATUS = (
         (1, "Active"),
         (2, "Completed"),
         (3, "Draft"),
-        (4, "Cancelled")
+        (4, "Cancelled"),
     )
     name = models.TextField()
-    product = models.ForeignKey(Product, on_delete=models.CASCADE, blank=True, null=True)
+    product = models.ForeignKey(
+        Product, on_delete=models.CASCADE, blank=True, null=True
+    )
     description = models.TextField(blank=True, null=True)
     status = models.IntegerField(choices=INITIATIVE_STATUS, default=1)
     video_url = models.URLField(blank=True, null=True)
@@ -133,7 +157,9 @@ class Initiative(TimeStampMixin, UUIDMixin):
         return self.name
 
     def get_available_challenges_count(self):
-        return self.challenge_set.filter(status=Challenge.CHALLENGE_STATUS_AVAILABLE).count()
+        return self.challenge_set.filter(
+            status=Challenge.CHALLENGE_STATUS_AVAILABLE
+        ).count()
 
     def get_completed_challenges_count(self):
         return self.challenge_set.filter(status=Challenge.CHALLENGE_STATUS_DONE).count()
@@ -175,7 +201,9 @@ class Initiative(TimeStampMixin, UUIDMixin):
 def save_initiative(sender, instance, created, **kwargs):
     if not created:
         # update challengelisting when initiative info is updated
-        ChallengeListing.objects.filter(initiative=instance).update(initiative_data=to_dict(instance))
+        ChallengeListing.objects.filter(initiative=instance).update(
+            initiative_data=to_dict(instance)
+        )
 
 
 class Challenge(TimeStampMixin, UUIDMixin):
@@ -192,54 +220,76 @@ class Challenge(TimeStampMixin, UUIDMixin):
         (CHALLENGE_STATUS_AVAILABLE, "Available"),
         (CHALLENGE_STATUS_CLAIMED, "Claimed"),
         (CHALLENGE_STATUS_DONE, "Done"),
-        (CHALLENGE_STATUS_IN_REVIEW, "In review")
+        (CHALLENGE_STATUS_IN_REVIEW, "In review"),
     )
-    CHALLENGE_PRIORITY = (
-        (0, 'High'),
-        (1, 'Medium'),
-        (2, 'Low')
-    )
+    CHALLENGE_PRIORITY = ((0, "High"), (1, "Medium"), (2, "Low"))
 
-    SKILL_MODE = (
-        (0, 'Single Skill'),
-        (1, 'Multiple Skills')
-    )
+    SKILL_MODE = ((0, "Single Skill"), (1, "Multiple Skills"))
 
     REWARD_TYPE = (
-        (0, 'Liquid Points'),
-        (1, 'Non-liquid Points'),
+        (0, "Liquid Points"),
+        (1, "Non-liquid Points"),
     )
 
-    initiative = models.ForeignKey(Initiative, on_delete=models.SET_NULL, blank=True, null=True)
-    capability = models.ForeignKey(Capability, on_delete=models.SET_NULL, blank=True, null=True)
+    initiative = models.ForeignKey(
+        Initiative, on_delete=models.SET_NULL, blank=True, null=True
+    )
+    capability = models.ForeignKey(
+        Capability, on_delete=models.SET_NULL, blank=True, null=True
+    )
     title = models.TextField()
     description = models.TextField()
     short_description = models.TextField(max_length=256)
     status = models.IntegerField(choices=CHALLENGE_STATUS, default=0)
-    attachment = models.ManyToManyField(Attachment, related_name="challenge_attachements", blank=True)
+    attachment = models.ManyToManyField(
+        Attachment, related_name="challenge_attachements", blank=True
+    )
     tag = models.ManyToManyField(Tag, related_name="challenge_tags", blank=True)
-    skill = models.ForeignKey(Skill, on_delete=models.CASCADE, related_name="challenge",
-                                 blank=True, null=True, default=None)
+    skill = models.ForeignKey(
+        Skill,
+        on_delete=models.CASCADE,
+        related_name="challenge",
+        blank=True,
+        null=True,
+        default=None,
+    )
     expertise = models.ManyToManyField(Expertise, related_name="challenge_expertise")
     blocked = models.BooleanField(default=False)
     featured = models.BooleanField(default=False)
     priority = models.IntegerField(choices=CHALLENGE_PRIORITY, default=1)
     published_id = models.IntegerField(default=0, blank=True, editable=False)
     auto_approve_task_claims = models.BooleanField(default=True)
-    created_by = models.ForeignKey("talent.Person", on_delete=models.CASCADE, blank=True, null=True,
-                                   related_name="created_by")
-    updated_by = models.ForeignKey("talent.Person", on_delete=models.CASCADE, blank=True, null=True,
-                                   related_name="updated_by")
+    created_by = models.ForeignKey(
+        "talent.Person",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="created_by",
+    )
+    updated_by = models.ForeignKey(
+        "talent.Person",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="updated_by",
+    )
     tracker = FieldTracker()
-    comments_start = models.ForeignKey(to="talent.challengecomment", on_delete=models.SET_NULL, null=True, editable=False)
+    comments_start = models.ForeignKey(
+        to="talent.challengecomment",
+        on_delete=models.SET_NULL,
+        null=True,
+        editable=False,
+    )
     reviewer = models.ForeignKey("talent.Person", on_delete=models.SET_NULL, null=True)
     product = models.ForeignKey(Product, on_delete=models.CASCADE, null=True)
     video_url = models.URLField(blank=True, null=True)
-    contribution_guide = models.ForeignKey("ContributorGuide",
-                                           null=True,
-                                           default=None,
-                                           blank=True,
-                                           on_delete=models.SET_NULL)
+    contribution_guide = models.ForeignKey(
+        "ContributorGuide",
+        null=True,
+        default=None,
+        blank=True,
+        on_delete=models.SET_NULL,
+    )
     skill_mode = models.IntegerField(choices=SKILL_MODE, default=0)
     reward_type = models.IntegerField(choices=REWARD_TYPE, default=1)
 
@@ -307,37 +357,46 @@ def save_challenge(sender, instance, created, **kwargs):
         reviewer = instance.reviewer
 
         # set contributor role for user if task is done
-        if instance.status == Challenge.CHALLENGE_STATUS_DONE and \
-            instance.tracker.previous('status') != Challenge.CHALLENGE_STATUS_DONE:
+        if (
+            instance.status == Challenge.CHALLENGE_STATUS_DONE
+            and instance.tracker.previous("status") != Challenge.CHALLENGE_STATUS_DONE
+        ):
             try:
                 bounty_claim = instance.taskclaim_set.filter(kind=0).first()
                 if bounty_claim:
                     product_person_data = dict(
-                        product_id=instance.product.id,
-                        person_id=bounty_claim.person.id
+                        product_id=instance.product.id, person_id=bounty_claim.person.id
                     )
-                    if not ProductRole.objects.filter(**product_person_data,
-                                                        right__in=[ProductRole.CONTRIBUTOR,
-                                                                   ProductRole.PRODUCT_ADMIN,
-                                                                   ProductRole.PRODUCT_MANAGER]).exists():
+                    if not ProductRole.objects.filter(
+                        **product_person_data,
+                        right__in=[
+                            ProductRole.CONTRIBUTOR,
+                            ProductRole.PRODUCT_ADMIN,
+                            ProductRole.PRODUCT_MANAGER,
+                        ],
+                    ).exists():
                         with transaction.atomic():
-                            ProductRole.objects.create(**product_person_data,
-                                                         right=ProductRole.CONTRIBUTOR)
+                            ProductRole.objects.create(
+                                **product_person_data, right=ProductRole.CONTRIBUTOR
+                            )
             except Exception as e:
                 print("Failed to change a user role", e, flush=True)
 
-        if instance.tracker.previous('status') != instance.status \
-                and instance.status == Challenge.CHALLENGE_STATUS_CLAIMED \
-                and reviewer:
-            engagement.tasks.send_notification.delay([Notification.Type.EMAIL],
-                                                       Notification.EventType.TASK_STATUS_CHANGED,
-                                                       receivers=[reviewer.id],
-                                                       title=instance.title,
-                                                       link=instance.get_challenge_link())
+        if (
+            instance.tracker.previous("status") != instance.status
+            and instance.status == Challenge.CHALLENGE_STATUS_CLAIMED
+            and reviewer
+        ):
+            engagement.tasks.send_notification.delay(
+                [Notification.Type.EMAIL],
+                Notification.EventType.TASK_STATUS_CHANGED,
+                receivers=[reviewer.id],
+                title=instance.title,
+                link=instance.get_challenge_link(),
+            )
     except Person.DoesNotExist:
         pass
-    
-    
+
     has_bountyclaim_in_review = False
     for bounty in instance.bounty_set.all():
         if bounty.bountyclaim_set.filter(kind=0).count() > 0:
@@ -348,7 +407,7 @@ def save_challenge(sender, instance, created, **kwargs):
         description=instance.description,
         short_description=instance.short_description,
         status=instance.status,
-        tags=list(instance.tag.all().values_list('name', flat=True)),
+        tags=list(instance.tag.all().values_list("name", flat=True)),
         blocked=instance.blocked,
         featured=instance.featured,
         priority=instance.priority,
@@ -364,14 +423,21 @@ def save_challenge(sender, instance, created, **kwargs):
             "owner": instance.product.get_product_owner().username,
             "website": instance.product.website,
             "detail_url": instance.product.detail_url,
-            "video_url": instance.product.video_url
-        } if instance.product else None,
+            "video_url": instance.product.video_url,
+        }
+        if instance.product
+        else None,
         product=instance.product,
-        has_active_depends=Challenge.objects.filter(challengedepend__challenge=instance.id).exclude(
-            status=Challenge.CHALLENGE_STATUS_DONE).exists(),
+        has_active_depends=Challenge.objects.filter(
+            challengedepend__challenge=instance.id
+        )
+        .exclude(status=Challenge.CHALLENGE_STATUS_DONE)
+        .exists(),
         initiative_id=instance.initiative.id if instance.initiative else None,
         initiative_data=to_dict(instance.initiative) if instance.initiative else None,
-        capability_id=instance.capability.id if instance.capability is not None else None,
+        capability_id=instance.capability.id
+        if instance.capability is not None
+        else None,
         capability_data=to_dict(instance.capability) if instance.capability else None,
         in_review=has_bountyclaim_in_review,
         video_url=instance.video_url,
@@ -382,10 +448,13 @@ def save_challenge(sender, instance, created, **kwargs):
     for bounty in instance.bounty_set.all():
         bounty_claim = bounty.bountyclaim_set.filter(kind__in=[0, 1]).first()
         if bounty_claim:
-            all_bounty_claim.append({
-                'bounty_claim': bounty_claim.id, 
-                'person': get_person_data(bounty_claim.person),
-                'person_id': '%s'%bounty_claim.person.id})
+            all_bounty_claim.append(
+                {
+                    "bounty_claim": bounty_claim.id,
+                    "person": get_person_data(bounty_claim.person),
+                    "person_id": "%s" % bounty_claim.person.id,
+                }
+            )
 
     if len(all_bounty_claim) > 0:
         challenge_listing_data["task_claim"] = all_bounty_claim
@@ -402,25 +471,31 @@ def save_challenge(sender, instance, created, **kwargs):
         product = instance.product
         last_product_challenge = None
         if product:
-            last_product_challenge = Challenge.objects \
-                .filter(productchallenge__product=product) \
-                .order_by('-published_id').last()
-        published_id = last_product_challenge.published_id + 1 if last_product_challenge else 1
+            last_product_challenge = (
+                Challenge.objects.filter(productchallenge__product=product)
+                .order_by("-published_id")
+                .last()
+            )
+        published_id = (
+            last_product_challenge.published_id + 1 if last_product_challenge else 1
+        )
         instance.published_id = published_id
         instance.save()
 
         challenge_listing_data["published_id"] = published_id
 
     # create TaskListing object
-    challengelisting_exist = ChallengeListing.objects.filter(challenge=instance).exists()
+    challengelisting_exist = ChallengeListing.objects.filter(
+        challenge=instance
+    ).exists()
 
     if challengelisting_exist:
-        ChallengeListing.objects.filter(challenge=instance).update(**challenge_listing_data)
-    else:
-        ChallengeListing.objects.create(
-            challenge=instance,
+        ChallengeListing.objects.filter(challenge=instance).update(
             **challenge_listing_data
         )
+    else:
+        ChallengeListing.objects.create(challenge=instance, **challenge_listing_data)
+
 
 class Bounty(TimeStampMixin):
     BOUNTY_STATUS_DRAFT = 0
@@ -436,12 +511,18 @@ class Bounty(TimeStampMixin):
         (BOUNTY_STATUS_AVAILABLE, "Available"),
         (BOUNTY_STATUS_CLAIMED, "Claimed"),
         (BOUNTY_STATUS_DONE, "Done"),
-        (BOUNTY_STATUS_IN_REVIEW, "In review")
+        (BOUNTY_STATUS_IN_REVIEW, "In review"),
     )
 
     challenge = models.ForeignKey(Challenge, on_delete=models.CASCADE)
-    skill = models.ForeignKey(Skill, on_delete=models.CASCADE, related_name="bounty_skill",
-                                 blank=True, null=True, default=None)
+    skill = models.ForeignKey(
+        Skill,
+        on_delete=models.CASCADE,
+        related_name="bounty_skill",
+        blank=True,
+        null=True,
+        default=None,
+    )
     expertise = models.ManyToManyField(Expertise, related_name="bounty_expertise")
     points = models.IntegerField()
     status = models.IntegerField(choices=BOUNTY_STATUS, default=BOUNTY_STATUS_AVAILABLE)
@@ -460,7 +541,9 @@ class ChallengeListing(models.Model):
     priority = models.IntegerField(choices=Challenge.CHALLENGE_PRIORITY, default=1)
     published_id = models.IntegerField(default=0, blank=True, editable=False)
     auto_approve_task_claims = models.BooleanField(default=True)
-    task_creator = models.ForeignKey(Person, on_delete=models.SET_NULL, related_name="creator", null=True)
+    task_creator = models.ForeignKey(
+        Person, on_delete=models.SET_NULL, related_name="creator", null=True
+    )
     created_by = models.JSONField()
     updated_by = models.JSONField()
     reviewer = models.JSONField(null=True)
@@ -470,7 +553,9 @@ class ChallengeListing(models.Model):
 
     task_claim = models.JSONField(null=True)
     assigned_to_data = models.JSONField(null=True)
-    assigned_to_person = models.ForeignKey(Person, on_delete=models.SET_NULL, null=True, related_name="challenge_listing")
+    assigned_to_person = models.ForeignKey(
+        Person, on_delete=models.SET_NULL, null=True, related_name="challenge_listing"
+    )
     has_active_depends = models.BooleanField(default=False)
     initiative = models.ForeignKey(Initiative, on_delete=models.SET_NULL, null=True)
     initiative_data = models.JSONField(null=True)
@@ -528,10 +613,12 @@ class ChallengeListing(models.Model):
 
 class ChallengeDependency(models.Model):
     preceding_challenge = models.ForeignKey(to=Challenge, on_delete=models.CASCADE)
-    subsequent_challenge = models.ForeignKey(to=Challenge, on_delete=models.CASCADE, related_name='Challenge')
+    subsequent_challenge = models.ForeignKey(
+        to=Challenge, on_delete=models.CASCADE, related_name="Challenge"
+    )
 
     class Meta:
-        db_table = 'product_management_challenge_dependencies'
+        db_table = "product_management_challenge_dependencies"
 
 
 class ProductChallenge(TimeStampMixin, UUIDMixin):
@@ -543,14 +630,23 @@ class ProductChallenge(TimeStampMixin, UUIDMixin):
 def save_product_task(sender, instance, created, **kwargs):
     if created:
         challenge = instance.challenge
-        last_product_challenge = Challenge.objects \
-            .filter(productchallenge__product=instance.product) \
-            .order_by('-published_id').first()
-        challenge.published_id = last_product_challenge.published_id + 1 if last_product_challenge else 1
+        last_product_challenge = (
+            Challenge.objects.filter(productchallenge__product=instance.product)
+            .order_by("-published_id")
+            .first()
+        )
+        challenge.published_id = (
+            last_product_challenge.published_id + 1 if last_product_challenge else 1
+        )
         challenge.save()
 
+
 class ContributorAgreement(models.Model):
-    product = models.ForeignKey(to=Product, on_delete=models.CASCADE, related_name="product_contributor_agreement")
+    product = models.ForeignKey(
+        to=Product,
+        on_delete=models.CASCADE,
+        related_name="product_contributor_agreement",
+    )
     agreement_content = models.TextField()
 
     class Meta:
@@ -559,7 +655,11 @@ class ContributorAgreement(models.Model):
 
 class ContributorAgreementAcceptance(models.Model):
     agreement = models.ForeignKey(to=ContributorAgreement, on_delete=models.CASCADE)
-    person = models.ForeignKey(to='talent.Person', on_delete=models.CASCADE, related_name="person_contributor_agreement_acceptance")
+    person = models.ForeignKey(
+        to="talent.Person",
+        on_delete=models.CASCADE,
+        related_name="person_contributor_agreement_acceptance",
+    )
     accepted_at = models.DateTimeField(auto_now_add=True, null=True)
 
     class Meta:
@@ -567,11 +667,19 @@ class ContributorAgreementAcceptance(models.Model):
 
 
 class ContributorGuide(models.Model):
-    product = models.ForeignKey(to=Product, on_delete=models.CASCADE, related_name="product_contributor_guide")
+    product = models.ForeignKey(
+        to=Product, on_delete=models.CASCADE, related_name="product_contributor_guide"
+    )
     title = models.CharField(max_length=60, unique=True)
     description = models.TextField(null=True, blank=True)
-    skill = models.ForeignKey(Skill, on_delete=models.CASCADE, related_name="category_contributor_guide", 
-                                    blank=True, null=True, default=None)
+    skill = models.ForeignKey(
+        Skill,
+        on_delete=models.CASCADE,
+        related_name="category_contributor_guide",
+        blank=True,
+        null=True,
+        default=None,
+    )
 
     def __str__(self):
         return self.title

--- a/product_management/services.py
+++ b/product_management/services.py
@@ -1,0 +1,46 @@
+from .models import Challenge, Initiative, Capability, Tag, Product
+
+
+class ChallengeService:
+    @staticmethod
+    def create(**kwargs):
+        challenge = Challenge(**kwargs)
+        challenge.save()
+
+        return challenge
+
+
+class InitiativeService:
+    @staticmethod
+    def create(**kwargs):
+        initiative = Initiative(**kwargs)
+        initiative.save()
+
+        return initiative
+
+
+class CapabilityService:
+    @staticmethod
+    def create(**kwargs):
+        capability = Capability(**kwargs)
+        capability.save()
+
+        return capability
+
+
+class TagService:
+    @staticmethod
+    def create(**kwargs):
+        tag = Tag(**kwargs)
+        tag.save()
+
+        return tag
+
+
+class ProductService:
+    @staticmethod
+    def create(**kwargs):
+        product = Product(**kwargs)
+        product.save()
+
+        return product

--- a/product_management/templates/product_management/challenges.html
+++ b/product_management/templates/product_management/challenges.html
@@ -7,11 +7,11 @@
 
   <div class="flex items-center justify-between w-full mb-12">
     <div class="flex items-center space-x-8 tabs-top">
-        <a href="#"
+        <a href=""
             class="active font-semibold py-3 text-sm inline-flex relative -mb-px text-[#1890ff] border-b-2 border-solid border-[#1890ff]">
             Challenges
         </a>
-        <a href="#"
+        <a href="{{ url('products') }}"
             class="font-semibold py-3 text-sm inline-flex relative -mb-px text-gray-900 border-b-2 border-solid border-transparent">Products</a>
     </div>
     <div
@@ -21,113 +21,111 @@
   </div>
 
   <div>
-    {{ challenges }}
+    <ul role="list" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+      {% for challenge in challenges %}
+      <li class="overflow-hidden rounded-xl border border-gray-200">
+        <div class="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-4">
+          <a href="/{{ challenge.product.owner.get_username() }}/{{ challenge.product.slug }}/challenges/{{ challenge.published_id }}"
+            class="text-lg font-medium leading-6 text-blue-400">{{ challenge.title }}</a>
+        </div>
+        <div class="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm leading-6">
+          <div class="py-3">
+            <div class="w-full truncate text-gray-500">
+              {{ challenge.short_description }}
+            </div>
+          </div>
+          <div class="py-3">
+            <div class="w-full font-semibold text-gray-500">Product</div>
+            <div class="flex justify-between gap-x-2">
+              {% if challenge.product.videoUrl %}
+              <button class="flex flex-none items-center cursor-pointer">
+                <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
+                  fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
+                  </path>
+                  <path
+                    d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
+                  </path>
+                </svg>
+              </button>
+              {% endif %}
+              <div class="flex-1">
+                <a class="text-blue-400"
+                  href="{{ challenge.product.owner.get_username() }}/{{ challenge.product.slug }}/">{{
+                  challenge.product.name }}</a>
+              </div>
+            </div>
+          </div>
+          {% if challenge.initiative %}
+          <div class="py-3">
+            <div class="w-full font-semibold text-gray-500">Initiative</div>
+            <div class="flex justify-between gap-x-2">
+              {% if challenge.initiative.video_url %}
+              <button class="flex flex-none items-center cursor-pointer">
+                <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
+                  fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
+                  </path>
+                  <path
+                    d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
+                  </path>
+                </svg>
+              </button>
+              {% endif %}
+              <div class="flex-1">
+                <a class="text-blue-400"
+                  href="/{{ challenge.product.owner.get_username() }}/{{ challenge.product.slug }}/initiatives/{{ challenge.initiative.id }}">
+                  {{ challenge.initiative.name }}
+                </a>
+              </div>
+            </div>
+          </div>
+          {% endif %}
+          <div class="flex gap-x-4 py-3">
+            <div class="font-semibold text-gray-500">Priority</div>
+            <div class="text-gray-500">
+              {{ challenge.get_priority_display() }}
+            </div>
+          </div>
+          <div class="flex gap-x-4 py-3">
+            <div class="font-semibold text-gray-500">Status</div>
+            <div class="text-gray-500">
+              {% if TASK_TYPES[challenge.status] == 'Claimed' %}
+              Claimed by <a class="text-blue-400" href="/{{ challenge.assignedToPerson.slug }}">{{
+                challenge.assignedToPerson.firstName }}</a>
+              {% elif TASK_TYPES[challenge.status] == 'In Review' %}
+              In Review <a class="text-blue-400" href="/{{ challenge.reviewer.username }}">{{
+                challenge.reviewer.firstName }}</a>
+              {% else %}
+              {{ TASK_TYPES[challenge.status] }}
+              {% endif %}
+            </div>
+          </div>
+          {% if challenge.category %}
+          <div class="py-3">
+            <div class="font-semibold text-gray-500 mb-1">Required skills</div>
+            <div>
+              <span class="text-gray-600 text-xs bg-gray-100 p-1">
+                {{ challenge.category }}
+                {% if challenge.expertise %}
+                (
+                {% for item in challenge.expertise %}
+                {{ item.name }}{% if item != challenge.expertise|last %}
+                {{ ', ' }}
+                {% endif %}
+                {% endfor %}
+                )
+                {% endif %}
+              </span>
+            </div>
+          </div>
+          {% endif %}
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
   </div>
-
-  <ul role="list" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-    {% for challenge_listing in challenge_listings %}
-    <li class="overflow-hidden rounded-xl border border-gray-200">
-      <div class="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-4">
-        <a href="/{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/challenges/{{ challenge_listing['publishedId'] }}"
-          class="text-lg font-medium leading-6 text-blue-400">{{ challenge_listing["title"] }}</a>
-      </div>
-      <div class="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm leading-6">
-        <div class="py-3">
-          <div class="w-full truncate text-gray-500">
-            {{ challenge_listing["shortDescription"] }}
-          </div>
-        </div>
-        <div class="py-3">
-          <div class="w-full font-semibold text-gray-500">Product</div>
-          <div class="flex justify-between gap-x-2">
-            {% if challenge_listing.product.videoUrl %}
-            <button class="flex flex-none items-center cursor-pointer">
-              <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
-                fill="currentColor" aria-hidden="true">
-                <path
-                  d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
-                </path>
-                <path
-                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
-                </path>
-              </svg>
-            </button>
-            {% endif %}
-            <div class="flex-1">
-              <a class="text-blue-400"
-                href="{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/">{{
-                challenge_listing.product.name }}</a>
-            </div>
-          </div>
-        </div>
-        {% if challenge_listing.initiative %}
-        <div class="py-3">
-          <div class="w-full font-semibold text-gray-500">Initiative</div>
-          <div class="flex justify-between gap-x-2">
-            {% if challenge_listing.initiative.videoUrl %}
-            <button class="flex flex-none items-center cursor-pointer">
-              <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
-                fill="currentColor" aria-hidden="true">
-                <path
-                  d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
-                </path>
-                <path
-                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
-                </path>
-              </svg>
-            </button>
-            {% endif %}
-            <div class="flex-1">
-              <a class="text-blue-400"
-                href="/{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/initiatives/{{ challenge_listing.initiative.id }}">
-                {{ challenge_listing.initiative.name }}
-              </a>
-            </div>
-          </div>
-        </div>
-        {% endif %}
-        <div class="flex gap-x-4 py-3">
-          <div class="font-semibold text-gray-500">Priority</div>
-          <div class="text-gray-500">
-            {{ challenge_listing.challenge.priority }}
-          </div>
-        </div>
-        <div class="flex gap-x-4 py-3">
-          <div class="font-semibold text-gray-500">Status</div>
-          <div class="text-gray-500">
-            {% if TASK_TYPES[challenge_listing.status] == 'Claimed' %}
-            Claimed by <a class="text-blue-400" href="/{{ challenge_listing.assignedToPerson.slug }}">{{
-              challenge_listing.assignedToPerson.firstName }}</a>
-            {% elif TASK_TYPES[challenge_listing.status] == 'In Review' %}
-            In Review <a class="text-blue-400" href="/{{ challenge_listing.reviewer.username }}">{{
-              challenge_listing.reviewer.firstName }}</a>
-            {% else %}
-            {{ TASK_TYPES[challenge_listing.status] }}
-            {% endif %}
-          </div>
-        </div>
-        {% if challenge_listing.category %}
-        <div class="py-3">
-          <div class="font-semibold text-gray-500 mb-1">Required skills</div>
-          <div>
-            <span class="text-gray-600 text-xs bg-gray-100 p-1">
-              {{ challenge_listing.category }}
-              {% if challenge_listing.expertise %}
-              (
-              {% for item in challenge_listing.expertise %}
-              {{ item.name }}{% if item != challenge_listing.expertise|last %}
-              {{ ', ' }}
-              {% endif %}
-              {% endfor %}
-              )
-              {% endif %}
-            </span>
-          </div>
-        </div>
-        {% endif %}
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
 </div>
 {% endblock %}

--- a/product_management/templates/product_management/challenges.html
+++ b/product_management/templates/product_management/challenges.html
@@ -1,0 +1,133 @@
+{% extends 'base.html' %}
+
+{% block title %}Homepage - Challenges Listed{% endblock %}
+{% block content %}
+
+<div class="flex flex-col">
+
+  <div class="flex items-center justify-between w-full mb-12">
+    <div class="flex items-center space-x-8 tabs-top">
+        <a href="#"
+            class="active font-semibold py-3 text-sm inline-flex relative -mb-px text-[#1890ff] border-b-2 border-solid border-[#1890ff]">
+            Challenges
+        </a>
+        <a href="#"
+            class="font-semibold py-3 text-sm inline-flex relative -mb-px text-gray-900 border-b-2 border-solid border-transparent">Products</a>
+    </div>
+    <div
+        class="ml-auto bg-[#1890ff] text-sm font-semibold leading-6 transition-all delay-600 rounded px-3.5 py-1.5 text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 cursor-pointer btn-modal__open">
+        Filter
+    </div>
+  </div>
+
+  <div>
+    {{ challenges }}
+  </div>
+
+  <ul role="list" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+    {% for challenge_listing in challenge_listings %}
+    <li class="overflow-hidden rounded-xl border border-gray-200">
+      <div class="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-4">
+        <a href="/{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/challenges/{{ challenge_listing['publishedId'] }}"
+          class="text-lg font-medium leading-6 text-blue-400">{{ challenge_listing["title"] }}</a>
+      </div>
+      <div class="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm leading-6">
+        <div class="py-3">
+          <div class="w-full truncate text-gray-500">
+            {{ challenge_listing["shortDescription"] }}
+          </div>
+        </div>
+        <div class="py-3">
+          <div class="w-full font-semibold text-gray-500">Product</div>
+          <div class="flex justify-between gap-x-2">
+            {% if challenge_listing.product.videoUrl %}
+            <button class="flex flex-none items-center cursor-pointer">
+              <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
+                fill="currentColor" aria-hidden="true">
+                <path
+                  d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
+                </path>
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
+                </path>
+              </svg>
+            </button>
+            {% endif %}
+            <div class="flex-1">
+              <a class="text-blue-400"
+                href="{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/">{{
+                challenge_listing.product.name }}</a>
+            </div>
+          </div>
+        </div>
+        {% if challenge_listing.initiative %}
+        <div class="py-3">
+          <div class="w-full font-semibold text-gray-500">Initiative</div>
+          <div class="flex justify-between gap-x-2">
+            {% if challenge_listing.initiative.videoUrl %}
+            <button class="flex flex-none items-center cursor-pointer">
+              <svg class="h-4 w-4 flex-none" viewBox="64 64 896 896" focusable="false" data-icon="play-square"
+                fill="currentColor" aria-hidden="true">
+                <path
+                  d="M442.3 677.6l199.4-156.7a11.3 11.3 0 000-17.7L442.3 346.4c-7.4-5.8-18.3-.6-18.3 8.8v313.5c0 9.4 10.9 14.7 18.3 8.9z">
+                </path>
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z">
+                </path>
+              </svg>
+            </button>
+            {% endif %}
+            <div class="flex-1">
+              <a class="text-blue-400"
+                href="/{{ challenge_listing.product.owner }}/{{ challenge_listing.product.slug }}/initiatives/{{ challenge_listing.initiative.id }}">
+                {{ challenge_listing.initiative.name }}
+              </a>
+            </div>
+          </div>
+        </div>
+        {% endif %}
+        <div class="flex gap-x-4 py-3">
+          <div class="font-semibold text-gray-500">Priority</div>
+          <div class="text-gray-500">
+            {{ challenge_listing.challenge.priority }}
+          </div>
+        </div>
+        <div class="flex gap-x-4 py-3">
+          <div class="font-semibold text-gray-500">Status</div>
+          <div class="text-gray-500">
+            {% if TASK_TYPES[challenge_listing.status] == 'Claimed' %}
+            Claimed by <a class="text-blue-400" href="/{{ challenge_listing.assignedToPerson.slug }}">{{
+              challenge_listing.assignedToPerson.firstName }}</a>
+            {% elif TASK_TYPES[challenge_listing.status] == 'In Review' %}
+            In Review <a class="text-blue-400" href="/{{ challenge_listing.reviewer.username }}">{{
+              challenge_listing.reviewer.firstName }}</a>
+            {% else %}
+            {{ TASK_TYPES[challenge_listing.status] }}
+            {% endif %}
+          </div>
+        </div>
+        {% if challenge_listing.category %}
+        <div class="py-3">
+          <div class="font-semibold text-gray-500 mb-1">Required skills</div>
+          <div>
+            <span class="text-gray-600 text-xs bg-gray-100 p-1">
+              {{ challenge_listing.category }}
+              {% if challenge_listing.expertise %}
+              (
+              {% for item in challenge_listing.expertise %}
+              {{ item.name }}{% if item != challenge_listing.expertise|last %}
+              {{ ', ' }}
+              {% endif %}
+              {% endfor %}
+              )
+              {% endif %}
+            </span>
+          </div>
+        </div>
+        {% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/product_management/templates/product_management/products.html
+++ b/product_management/templates/product_management/products.html
@@ -1,0 +1,1 @@
+Hello, world

--- a/product_management/urls.py
+++ b/product_management/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 
-from .views import ChallengeListView
+from .views import ChallengeListView, ProductListView
 
-urlpatterns = [path("challenges/", ChallengeListView.as_view(), name="challenges")]
+urlpatterns = [
+    path("challenges/", ChallengeListView.as_view(), name="challenges"),
+    path("products/", ProductListView.as_view(), name="products"),
+]

--- a/product_management/urls.py
+++ b/product_management/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path
+
+from .views import ChallengeListView
+
+urlpatterns = [path("challenges/", ChallengeListView.as_view(), name="challenges")]

--- a/product_management/views.py
+++ b/product_management/views.py
@@ -1,3 +1,13 @@
 from django.shortcuts import render
+from django.views.generic import ListView
 
-# Create your views here.
+from .models import Challenge
+
+
+class ChallengeListView(ListView):
+    model = Challenge
+    context_object_name = "challenges"
+    template_name = "product_management/challenges.html"
+
+    def get(self, request, *args, **kwargs):
+        return render(request, self.template_name)

--- a/product_management/views.py
+++ b/product_management/views.py
@@ -1,7 +1,6 @@
-from django.shortcuts import render
 from django.views.generic import ListView
 
-from .models import Challenge
+from .models import Challenge, Product
 
 
 class ChallengeListView(ListView):
@@ -9,5 +8,24 @@ class ChallengeListView(ListView):
     context_object_name = "challenges"
     template_name = "product_management/challenges.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["request"] = self.request
+
+        return context
+
     def get(self, request, *args, **kwargs):
-        return render(request, self.template_name)
+        response = super().get(request, *args, **kwargs)
+
+        return response
+
+
+class ProductListView(ListView):
+    model = Product
+    context_object_name = "products"
+    template_name = "product_management/products.html"
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+
+        return response

--- a/sample_data/cart.json
+++ b/sample_data/cart.json
@@ -1,0 +1,56 @@
+[
+    {
+        "number_of_points": 1000,
+        "currency_of_payment": 1,
+        "price_per_point_in_cents": 100,
+        "subtotal_in_cents": 10,
+        "sales_tax_in_cents": 19,
+        "total_payable_in_cents": 29,
+        "payment_type": 1
+    },
+    {
+        "number_of_points": 1000,
+        "currency_of_payment": 1,
+        "price_per_point_in_cents": 200,
+        "subtotal_in_cents": 10,
+        "sales_tax_in_cents": 19,
+        "total_payable_in_cents": 29,
+        "payment_type": 1
+    },
+    {
+        "number_of_points": 2000,
+        "currency_of_payment": 2,
+        "price_per_point_in_cents": 300,
+        "subtotal_in_cents": 20,
+        "sales_tax_in_cents": 29,
+        "total_payable_in_cents": 39,
+        "payment_type": 1
+    },
+    {
+        "number_of_points": 2000,
+        "currency_of_payment": 2,
+        "price_per_point_in_cents": 100,
+        "subtotal_in_cents": 20,
+        "sales_tax_in_cents": 29,
+        "total_payable_in_cents": 39,
+        "payment_type": 1
+    },
+    {
+        "number_of_points": 3000,
+        "currency_of_payment": 3,
+        "price_per_point_in_cents": 200,
+        "subtotal_in_cents": 30,
+        "sales_tax_in_cents": 39,
+        "total_payable_in_cents": 49,
+        "payment_type": 1
+    },
+    {
+        "number_of_points": 3000,
+        "currency_of_payment": 3,
+        "price_per_point_in_cents": 300,
+        "subtotal_in_cents": 30,
+        "sales_tax_in_cents": 39,
+        "total_payable_in_cents": 49,
+        "payment_type": 1
+    }
+]

--- a/sample_data/challenge.json
+++ b/sample_data/challenge.json
@@ -1,0 +1,42 @@
+[
+    {
+        "title": "Challenge 1",
+        "short_description": "Short Description 1",
+        "description": "Description 1",
+        "status": 2,
+        "published_id": 1,
+        "video_url": "",
+        "skill_mode": 0,
+        "reward_type": 0
+    },
+    {
+        "title": "Challenge 2",
+        "short_description": "Short Description 2",
+        "description": "Description 2",
+        "status": 2,
+        "published_id": 2,
+        "video_url": "",
+        "skill_mode": 0,
+        "reward_type": 0
+    },
+    {
+        "title": "Challenge 3",
+        "short_description": "Short Description 3",
+        "description": "Description 3",
+        "status": 2,
+        "published_id": 3,
+        "video_url": "",
+        "skill_mode": 0,
+        "reward_type": 0
+    },
+    {
+        "title": "Challenge 4",
+        "short_description": "Short Description 4",
+        "description": "Description 4",
+        "status": 2,
+        "published_id": 4,
+        "video_url": "",
+        "skill_mode": 0,
+        "reward_type": 0
+    }
+]

--- a/sample_data/expertise.json
+++ b/sample_data/expertise.json
@@ -1,0 +1,247 @@
+[
+    {
+        "id": 1,
+        "selectable": false,
+        "name": "tools",
+        "parent_id": null,
+        "skill_id": 92
+    },
+    {
+        "id": 2,
+        "selectable": true,
+        "name": "figma",
+        "parent_id": 1,
+        "skill_id": 92
+    },
+    {
+        "id": 3,
+        "selectable": false,
+        "name": "activities",
+        "parent_id": null,
+        "skill_id": 93
+    },
+    {
+        "id": 4,
+        "selectable": true,
+        "name": "interviews",
+        "parent_id": 3,
+        "skill_id": 93
+    },
+    {
+        "id": 5,
+        "selectable": false,
+        "name": "tools",
+        "parent_id": null,
+        "skill_id": 94
+    },
+    {
+        "id": 6,
+        "selectable": true,
+        "name": "figma",
+        "parent_id": 5,
+        "skill_id": 94
+    },
+    {
+        "id": 7,
+        "selectable": true,
+        "name": "adobe xd",
+        "parent_id": 5,
+        "skill_id": 94
+    },
+    {
+        "id": 8,
+        "selectable": true,
+        "name": "invision",
+        "parent_id": 5,
+        "skill_id": 94
+    },
+    {
+        "id": 9,
+        "selectable": false,
+        "name": "design-systems",
+        "parent_id": null,
+        "skill_id": 94
+    },
+    {
+        "id": 10,
+        "selectable": true,
+        "name": "ant-design",
+        "parent_id": 9,
+        "skill_id": 94
+    },
+    {
+        "id": 11,
+        "selectable": true,
+        "name": "material-design",
+        "parent_id": 9,
+        "skill_id": 94
+    },
+    {
+        "id": 12,
+        "selectable": false,
+        "name": "python ecosystem",
+        "parent_id": null,
+        "skill_id": 97
+    },
+    {
+        "id": 13,
+        "selectable": true,
+        "name": "django",
+        "parent_id": 12,
+        "skill_id": 97
+    },
+    {
+        "id": 14,
+        "selectable": true,
+        "name": "flask",
+        "parent_id": 12,
+        "skill_id": 97
+    },
+    {
+        "id": 15,
+        "selectable": false,
+        "name": "java ecosystem",
+        "parent_id": null,
+        "skill_id": 97
+    },
+    {
+        "id": 16,
+        "selectable": true,
+        "name": "java",
+        "parent_id": 15,
+        "skill_id": 97
+    },
+    {
+        "id": 17,
+        "selectable": true,
+        "name": "spring-boot",
+        "parent_id": 15,
+        "skill_id": 97
+    },
+    {
+        "id": 18,
+        "selectable": false,
+        "name": "languages",
+        "parent_id": null,
+        "skill_id": 97
+    },
+    {
+        "id": 19,
+        "selectable": true,
+        "name": "golang",
+        "parent_id": 18,
+        "skill_id": 97
+    },
+    {
+        "id": 20,
+        "selectable": true,
+        "name": "python",
+        "parent_id": 18,
+        "skill_id": 97
+    },
+    {
+        "id": 21,
+        "selectable": true,
+        "name": "java",
+        "parent_id": 18,
+        "skill_id": 97
+    },
+    {
+        "id": 22,
+        "selectable": false,
+        "name": "libraries",
+        "parent_id": null,
+        "skill_id": 105
+    },
+    {
+        "id": 23,
+        "selectable": true,
+        "name": "react",
+        "parent_id": 22,
+        "skill_id": 105
+    },
+    {
+        "id": 24,
+        "selectable": true,
+        "name": "redux",
+        "parent_id": 22,
+        "skill_id": 105
+    },
+    {
+        "id": 25,
+        "selectable": true,
+        "name": "vue",
+        "parent_id": 22,
+        "skill_id": 105
+    },
+    {
+        "id": 26,
+        "selectable": false,
+        "name": "languages",
+        "parent_id": null,
+        "skill_id": 105
+    },
+    {
+        "id": 27,
+        "selectable": true,
+        "name": "javascript",
+        "parent_id": 26,
+        "skill_id": 105
+    },
+    {
+        "id": 28,
+        "selectable": true,
+        "name": "typescript",
+        "parent_id": 26,
+        "skill_id": 105
+    },
+    {
+        "id": 29,
+        "selectable": false,
+        "name": "technologies",
+        "parent_id": null,
+        "skill_id": 105
+    },
+    {
+        "id": 30,
+        "selectable": true,
+        "name": "graphql",
+        "parent_id": 29,
+        "skill_id": 105
+    },
+    {
+        "id": 31,
+        "selectable": true,
+        "name": "rest",
+        "parent_id": 29,
+        "skill_id": 105
+    },
+    {
+        "id": 32,
+        "selectable": false,
+        "name": "frameworks",
+        "parent_id": null,
+        "skill_id": 106
+    },
+    {
+        "id": 33,
+        "selectable": true,
+        "name": "django",
+        "parent_id": 32,
+        "skill_id": 106
+    },
+    {
+        "id": 34,
+        "selectable": false,
+        "name": "frameworks",
+        "parent_id": null,
+        "skill_id": 114
+    },
+    {
+        "id": 35,
+        "selectable": true,
+        "name": "cypress",
+        "parent_id": 34,
+        "skill_id": 114
+    }
+]

--- a/sample_data/initiative.json
+++ b/sample_data/initiative.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "Initiative 1",
+        "description": "Initiative Description 1",
+        "status": 1,
+        "video_url": "http://www.invalid_initiative_url.com"
+    },
+    {
+        "name": "Initiative 2",
+        "description": "Initiative Description 2",
+        "status": 2,
+        "video_url": "http://www.invalid_initiative_url.com"
+    },
+    {
+        "name": "Initiative 3",
+        "description": "Initiative Description 3",
+        "status": 3,
+        "video_url": "http://www.invalid_initiative_url.com"
+    },
+    {
+        "name": "Initiative 4",
+        "description": "Initiative Description 4",
+        "status": 4,
+        "video_url": "http://www.invalid_initiative_url.com"
+    },
+    {
+        "name": "Initiative 5",
+        "description": "Initiative Description 5",
+        "status": 1,
+        "video_url": "http://www.invalid_initiative_url.com"
+    }
+]

--- a/sample_data/model_app_mapping.json
+++ b/sample_data/model_app_mapping.json
@@ -1,0 +1,14 @@
+{
+    "Organisation": "commerce",
+    "OrganisationAccount": "commerce",
+    "OrganisationAccountCredit": "commerce",
+    "Cart": "commerce",
+    "Person": "talent",
+    "Skill": "talent",
+    "Expertise": "talent",
+    "Product": "product_management",
+    "Initiative": "product_management",
+    "Capability": "product_management",
+    "Challenge": "product_management",
+    "Tag": "product_management"
+}

--- a/sample_data/organisation.json
+++ b/sample_data/organisation.json
@@ -1,0 +1,26 @@
+[
+    {
+        "username": "organisation_username_one",
+        "name": "organisation_name_one"
+    },
+    {
+        "username": "organisation_username_two",
+        "name": "organisation_name_two"
+    },
+    {
+        "username": "organisation_username_three",
+        "name": "organisation_name_three"
+    },
+    {
+        "username": "organisation_username_four",
+        "name": "organisation_name_four"
+    },
+    {
+        "username": "organisation_username_five",
+        "name": "organisation_name_five"
+    },
+    {
+        "username": "organisation_username_six",
+        "name": "organisation_name_six"
+    }
+]

--- a/sample_data/organisation_account.json
+++ b/sample_data/organisation_account.json
@@ -1,0 +1,26 @@
+[
+    {
+        "liquid_points_balance": 10,
+        "nonliquid_points_balance": 10
+    },
+    {
+        "liquid_points_balance": 20,
+        "nonliquid_points_balance": 20
+    },
+    {
+        "liquid_points_balance": 30,
+        "nonliquid_points_balance": 30
+    },
+    {
+        "liquid_points_balance": 40,
+        "nonliquid_points_balance": 40
+    },
+    {
+        "liquid_points_balance": 50,
+        "nonliquid_points_balance": 50
+    },
+    {
+        "liquid_points_balance": 60,
+        "nonliquid_points_balance": 60
+    }
+]

--- a/sample_data/organisation_account_credit.json
+++ b/sample_data/organisation_account_credit.json
@@ -1,0 +1,32 @@
+[
+    {
+        "number_of_points": 10,
+        "type_of_points": 1,
+        "credit_reason": 1
+    },
+    {
+        "number_of_points": 20,
+        "type_of_points": 1,
+        "credit_reason": 1
+    },
+    {
+        "number_of_points": 30,
+        "type_of_points": 1,
+        "credit_reason": 1
+    },
+    {
+        "number_of_points": 40,
+        "type_of_points": 2,
+        "credit_reason": 2
+    },
+    {
+        "number_of_points": 50,
+        "type_of_points": 2,
+        "credit_reason": 2
+    },
+    {
+        "number_of_points": 60,
+        "type_of_points": 2,
+        "credit_reason": 2
+    }
+]

--- a/sample_data/person.json
+++ b/sample_data/person.json
@@ -1,0 +1,33 @@
+[
+    {
+        "first_name": "Doğukan",
+        "last_name": "Teber",
+        "email": "dogukan@example.com",
+        "username": "dogukan",
+        "password": "dogukan",
+        "headline": "Super lorem ipsum sit amet",
+        "overview": "Super user",
+        "is_staff": true,
+        "is_superuser": true
+    },
+    {
+        "first_name": "Gary",
+        "last_name": "Test",
+        "email": "test+gary@openunited.com",
+        "username": "garyg",
+        "password": "123456789",
+        "headline": "Lorem ipsum sit amet",
+        "overview": "Test test test",
+        "is_test_user": true
+    },
+    {
+        "first_name": "Shirley",
+        "last_name": "Test",
+        "email": "test+shirley@openunited.com",
+        "username": "shirleyaghost",
+        "password": "123456789",
+        "headline": "Lorem ipsum sit amet",
+        "overview": "Test test test",
+        "is_test_user": true
+    }
+]

--- a/sample_data/product.json
+++ b/sample_data/product.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "Product 1",
+        "short_description": "Product Short Description 1",
+        "full_description": "Product Full Description 1",
+        "website": "http://www.invalid_product_website.com",
+        "detail_url": "http://detail_url",
+        "video_url": "http://video_url"
+    },
+    {
+        "name": "Product 2",
+        "short_description": "Product Short Description 2",
+        "full_description": "Product Full Description 2",
+        "website": "http://www.invalid_product_website.com",
+        "detail_url": "http://detail_url",
+        "video_url": "http://video_url"
+    },
+    {
+        "name": "Product 3",
+        "short_description": "Product Short Description 3",
+        "full_description": "Product Full Description 3",
+        "website": "http://www.invalid_product_website.com",
+        "detail_url": "http://detail_url",
+        "video_url": "http://video_url"
+    },
+    {
+        "name": "Product 4",
+        "short_description": "Product Short Description 4",
+        "full_description": "Product Full Description 4",
+        "website": "http://www.invalid_product_website.com",
+        "detail_url": "http://detail_url",
+        "video_url": "http://video_url"
+    },
+    {
+        "name": "Product 5",
+        "short_description": "Product Short Description 5",
+        "full_description": "Product Full Description 5",
+        "website": "http://www.invalid_product_website.com",
+        "detail_url": "http://detail_url",
+        "video_url": "http://video_url"
+    }
+]

--- a/sample_data/skill.json
+++ b/sample_data/skill.json
@@ -1,0 +1,919 @@
+[
+    {
+        "id": 1,
+        "active": false,
+        "selectable": false,
+        "name": "Art & Creative",
+        "parent_id": null
+    },
+    {
+        "id": 2,
+        "active": false,
+        "selectable": false,
+        "name": "2D Animation",
+        "parent_id": 1
+    },
+    {
+        "id": 3,
+        "active": false,
+        "selectable": false,
+        "name": "Acting",
+        "parent_id": 1
+    },
+    {
+        "id": 4,
+        "active": false,
+        "selectable": false,
+        "name": "AR/VR Design",
+        "parent_id": 1
+    },
+    {
+        "id": 5,
+        "active": false,
+        "selectable": false,
+        "name": "Art Direction",
+        "parent_id": 1
+    },
+    {
+        "id": 6,
+        "active": false,
+        "selectable": false,
+        "name": "Audio Editing",
+        "parent_id": 1
+    },
+    {
+        "id": 7,
+        "active": false,
+        "selectable": false,
+        "name": "Audio Production",
+        "parent_id": 1
+    },
+    {
+        "id": 8,
+        "active": false,
+        "selectable": false,
+        "name": "Brand Design",
+        "parent_id": 1
+    },
+    {
+        "id": 9,
+        "active": false,
+        "selectable": false,
+        "name": "Caricatures & Portraits",
+        "parent_id": 1
+    },
+    {
+        "id": 10,
+        "active": false,
+        "selectable": false,
+        "name": "Cartoons & Comics",
+        "parent_id": 1
+    },
+    {
+        "id": 11,
+        "active": false,
+        "selectable": false,
+        "name": "Creative Direction",
+        "parent_id": 1
+    },
+    {
+        "id": 12,
+        "active": false,
+        "selectable": false,
+        "name": "Editorial Design",
+        "parent_id": 1
+    },
+    {
+        "id": 13,
+        "active": false,
+        "selectable": false,
+        "name": "Game Art",
+        "parent_id": 1
+    },
+    {
+        "id": 14,
+        "active": false,
+        "selectable": false,
+        "name": "Local Photography",
+        "parent_id": 1
+    },
+    {
+        "id": 15,
+        "active": false,
+        "selectable": false,
+        "name": "Motion Graphics",
+        "parent_id": 1
+    },
+    {
+        "id": 16,
+        "active": false,
+        "selectable": false,
+        "name": "Image Editing",
+        "parent_id": 1
+    },
+    {
+        "id": 17,
+        "active": false,
+        "selectable": false,
+        "name": "Music Composition",
+        "parent_id": 1
+    },
+    {
+        "id": 18,
+        "active": false,
+        "selectable": false,
+        "name": "Music Production",
+        "parent_id": 1
+    },
+    {
+        "id": 19,
+        "active": false,
+        "selectable": false,
+        "name": "Musician",
+        "parent_id": 1
+    },
+    {
+        "id": 20,
+        "active": false,
+        "selectable": false,
+        "name": "Packaging Design",
+        "parent_id": 1
+    },
+    {
+        "id": 21,
+        "active": false,
+        "selectable": false,
+        "name": "Pattern Design",
+        "parent_id": 1
+    },
+    {
+        "id": 22,
+        "active": false,
+        "selectable": false,
+        "name": "Presentation Design",
+        "parent_id": 1
+    },
+    {
+        "id": 23,
+        "active": false,
+        "selectable": false,
+        "name": "Product & Industrial Design",
+        "parent_id": 1
+    },
+    {
+        "id": 24,
+        "active": false,
+        "selectable": false,
+        "name": "Product Photography",
+        "parent_id": 1
+    },
+    {
+        "id": 25,
+        "active": false,
+        "selectable": false,
+        "name": "Video Editing",
+        "parent_id": 1
+    },
+    {
+        "id": 26,
+        "active": false,
+        "selectable": false,
+        "name": "Video Production",
+        "parent_id": 1
+    },
+    {
+        "id": 27,
+        "active": false,
+        "selectable": false,
+        "name": "3D Animation",
+        "parent_id": 1
+    },
+    {
+        "id": 28,
+        "active": false,
+        "selectable": false,
+        "name": "Videography",
+        "parent_id": 1
+    },
+    {
+        "id": 29,
+        "active": false,
+        "selectable": false,
+        "name": "Visual Effects",
+        "parent_id": 1
+    },
+    {
+        "id": 30,
+        "active": false,
+        "selectable": false,
+        "name": "Customer Service & Support",
+        "parent_id": null
+    },
+    {
+        "id": 31,
+        "active": false,
+        "selectable": false,
+        "name": "Customer Service",
+        "parent_id": 30
+    },
+    {
+        "id": 32,
+        "active": false,
+        "selectable": false,
+        "name": "Tech Support",
+        "parent_id": 30
+    },
+    {
+        "id": 33,
+        "active": false,
+        "selectable": false,
+        "name": "Data Science & Analytics",
+        "parent_id": null
+    },
+    {
+        "id": 34,
+        "active": false,
+        "selectable": false,
+        "name": "Data Analytics",
+        "parent_id": 33
+    },
+    {
+        "id": 35,
+        "active": false,
+        "selectable": false,
+        "name": "Data Engineering",
+        "parent_id": 33
+    },
+    {
+        "id": 36,
+        "active": false,
+        "selectable": false,
+        "name": "Data Extraction",
+        "parent_id": 33
+    },
+    {
+        "id": 37,
+        "active": false,
+        "selectable": false,
+        "name": "Data Mining",
+        "parent_id": 33
+    },
+    {
+        "id": 38,
+        "active": false,
+        "selectable": false,
+        "name": "Data Processing",
+        "parent_id": 33
+    },
+    {
+        "id": 39,
+        "active": false,
+        "selectable": false,
+        "name": "Data Visualization",
+        "parent_id": 33
+    },
+    {
+        "id": 40,
+        "active": false,
+        "selectable": false,
+        "name": "Deep Learning",
+        "parent_id": 33
+    },
+    {
+        "id": 41,
+        "active": false,
+        "selectable": false,
+        "name": "Experimentation & Testing",
+        "parent_id": 33
+    },
+    {
+        "id": 42,
+        "active": false,
+        "selectable": false,
+        "name": "Knowledge Representation",
+        "parent_id": 33
+    },
+    {
+        "id": 43,
+        "active": false,
+        "selectable": false,
+        "name": "Machine Learning",
+        "parent_id": 33
+    },
+    {
+        "id": 44,
+        "active": false,
+        "selectable": false,
+        "name": "Engineering, Science & Building",
+        "parent_id": null
+    },
+    {
+        "id": 45,
+        "active": false,
+        "selectable": false,
+        "name": "3D Modelling & Rendering",
+        "parent_id": 44
+    },
+    {
+        "id": 46,
+        "active": false,
+        "selectable": false,
+        "name": "Building Information Modelling",
+        "parent_id": 44
+    },
+    {
+        "id": 47,
+        "active": false,
+        "selectable": false,
+        "name": "Mathematics",
+        "parent_id": 44
+    },
+    {
+        "id": 48,
+        "active": false,
+        "selectable": false,
+        "name": "Sourcing & Procurement",
+        "parent_id": 44
+    },
+    {
+        "id": 49,
+        "active": false,
+        "selectable": false,
+        "name": "General Support",
+        "parent_id": null
+    },
+    {
+        "id": 50,
+        "active": false,
+        "selectable": false,
+        "name": "Accounting & Finance",
+        "parent_id": 49
+    },
+    {
+        "id": 51,
+        "active": false,
+        "selectable": false,
+        "name": "Legal Support",
+        "parent_id": 49
+    },
+    {
+        "id": 52,
+        "active": false,
+        "selectable": false,
+        "name": "Project Management",
+        "parent_id": 49
+    },
+    {
+        "id": 53,
+        "active": false,
+        "selectable": false,
+        "name": "Agile Coach",
+        "parent_id": 49
+    },
+    {
+        "id": 54,
+        "active": true,
+        "selectable": false,
+        "name": "Information Systems & Networking",
+        "parent_id": null
+    },
+    {
+        "id": 55,
+        "active": false,
+        "selectable": false,
+        "name": "Business Applications Development",
+        "parent_id": 54
+    },
+    {
+        "id": 56,
+        "active": true,
+        "selectable": true,
+        "name": "Cloud Engineering",
+        "parent_id": 54
+    },
+    {
+        "id": 57,
+        "active": false,
+        "selectable": false,
+        "name": "Database Administration",
+        "parent_id": 54
+    },
+    {
+        "id": 58,
+        "active": true,
+        "selectable": true,
+        "name": "DevOps Engineering",
+        "parent_id": 54
+    },
+    {
+        "id": 59,
+        "active": true,
+        "selectable": true,
+        "name": "Information Security",
+        "parent_id": 54
+    },
+    {
+        "id": 60,
+        "active": false,
+        "selectable": false,
+        "name": "IT Compliance",
+        "parent_id": 54
+    },
+    {
+        "id": 61,
+        "active": false,
+        "selectable": false,
+        "name": "IT Support",
+        "parent_id": 54
+    },
+    {
+        "id": 62,
+        "active": false,
+        "selectable": false,
+        "name": "Network Administration",
+        "parent_id": 54
+    },
+    {
+        "id": 63,
+        "active": false,
+        "selectable": false,
+        "name": "Network Security",
+        "parent_id": 54
+    },
+    {
+        "id": 64,
+        "active": true,
+        "selectable": true,
+        "name": "Solutions Architecture",
+        "parent_id": 54
+    },
+    {
+        "id": 65,
+        "active": false,
+        "selectable": false,
+        "name": "Systems Administration",
+        "parent_id": 54
+    },
+    {
+        "id": 66,
+        "active": false,
+        "selectable": false,
+        "name": "Systems Engineering",
+        "parent_id": 54
+    },
+    {
+        "id": 67,
+        "active": false,
+        "selectable": false,
+        "name": "Marketing, Sales & Communications",
+        "parent_id": null
+    },
+    {
+        "id": 68,
+        "active": false,
+        "selectable": false,
+        "name": "Brand Strategy",
+        "parent_id": 67
+    },
+    {
+        "id": 69,
+        "active": false,
+        "selectable": false,
+        "name": "Campaign Management",
+        "parent_id": 67
+    },
+    {
+        "id": 70,
+        "active": false,
+        "selectable": false,
+        "name": "Community Management",
+        "parent_id": 67
+    },
+    {
+        "id": 71,
+        "active": false,
+        "selectable": false,
+        "name": "Content Strategy",
+        "parent_id": 67
+    },
+    {
+        "id": 72,
+        "active": false,
+        "selectable": false,
+        "name": "Digital Marketing",
+        "parent_id": 67
+    },
+    {
+        "id": 73,
+        "active": false,
+        "selectable": false,
+        "name": "Email Marketing",
+        "parent_id": 67
+    },
+    {
+        "id": 74,
+        "active": false,
+        "selectable": false,
+        "name": "Lead Generation",
+        "parent_id": 67
+    },
+    {
+        "id": 75,
+        "active": false,
+        "selectable": false,
+        "name": "Market Research",
+        "parent_id": 67
+    },
+    {
+        "id": 76,
+        "active": false,
+        "selectable": false,
+        "name": "Marketing Automation",
+        "parent_id": 67
+    },
+    {
+        "id": 77,
+        "active": false,
+        "selectable": false,
+        "name": "Marketing Strategy",
+        "parent_id": 67
+    },
+    {
+        "id": 78,
+        "active": false,
+        "selectable": false,
+        "name": "Public relations",
+        "parent_id": 67
+    },
+    {
+        "id": 79,
+        "active": false,
+        "selectable": false,
+        "name": "Sales & Business Development",
+        "parent_id": 67
+    },
+    {
+        "id": 80,
+        "active": false,
+        "selectable": false,
+        "name": "Search Engine Marketing",
+        "parent_id": 67
+    },
+    {
+        "id": 81,
+        "active": false,
+        "selectable": false,
+        "name": "Search Engine Optimisation",
+        "parent_id": 67
+    },
+    {
+        "id": 82,
+        "active": false,
+        "selectable": false,
+        "name": "Social Media Marketing",
+        "parent_id": 67
+    },
+    {
+        "id": 83,
+        "active": false,
+        "selectable": false,
+        "name": "Social Media Strategy",
+        "parent_id": 67
+    },
+    {
+        "id": 84,
+        "active": false,
+        "selectable": false,
+        "name": "Telemarketing",
+        "parent_id": 67
+    },
+    {
+        "id": 85,
+        "active": true,
+        "selectable": false,
+        "name": "Product, User Experience & Research",
+        "parent_id": null
+    },
+    {
+        "id": 86,
+        "active": true,
+        "selectable": true,
+        "name": "Business Analysis",
+        "parent_id": 85
+    },
+    {
+        "id": 87,
+        "active": true,
+        "selectable": true,
+        "name": "Graphic Design",
+        "parent_id": 85
+    },
+    {
+        "id": 88,
+        "active": false,
+        "selectable": false,
+        "name": "Illustration",
+        "parent_id": 85
+    },
+    {
+        "id": 89,
+        "active": false,
+        "selectable": false,
+        "name": "Initiative Management",
+        "parent_id": 85
+    },
+    {
+        "id": 90,
+        "active": false,
+        "selectable": false,
+        "name": "Logo Design",
+        "parent_id": 85
+    },
+    {
+        "id": 91,
+        "active": true,
+        "selectable": true,
+        "name": "Product Management",
+        "parent_id": 85
+    },
+    {
+        "id": 92,
+        "active": true,
+        "selectable": true,
+        "name": "UI Mockups",
+        "parent_id": 85
+    },
+    {
+        "id": 93,
+        "active": true,
+        "selectable": true,
+        "name": "User Research",
+        "parent_id": 85
+    },
+    {
+        "id": 94,
+        "active": true,
+        "selectable": true,
+        "name": "UX/UI Design",
+        "parent_id": 85
+    },
+    {
+        "id": 95,
+        "active": true,
+        "selectable": false,
+        "name": "Software Development (inc. Web, Mobile)",
+        "parent_id": null
+    },
+    {
+        "id": 96,
+        "active": false,
+        "selectable": false,
+        "name": "AR/VR Development",
+        "parent_id": 95
+    },
+    {
+        "id": 97,
+        "active": true,
+        "selectable": true,
+        "name": "Backend Development",
+        "parent_id": 95
+    },
+    {
+        "id": 98,
+        "active": false,
+        "selectable": false,
+        "name": "Blockchain Development",
+        "parent_id": 95
+    },
+    {
+        "id": 99,
+        "active": false,
+        "selectable": false,
+        "name": "CMS Development",
+        "parent_id": 95
+    },
+    {
+        "id": 100,
+        "active": false,
+        "selectable": false,
+        "name": "Database Development",
+        "parent_id": 95
+    },
+    {
+        "id": 101,
+        "active": false,
+        "selectable": false,
+        "name": "Desktop Software Development",
+        "parent_id": 95
+    },
+    {
+        "id": 102,
+        "active": false,
+        "selectable": false,
+        "name": "E-commerce Development",
+        "parent_id": 95
+    },
+    {
+        "id": 103,
+        "active": false,
+        "selectable": false,
+        "name": "Emerging Tech",
+        "parent_id": 95
+    },
+    {
+        "id": 104,
+        "active": false,
+        "selectable": false,
+        "name": "Firmware Development",
+        "parent_id": 95
+    },
+    {
+        "id": 105,
+        "active": true,
+        "selectable": true,
+        "name": "Frontend Development",
+        "parent_id": 95
+    },
+    {
+        "id": 106,
+        "active": true,
+        "selectable": true,
+        "name": "Full-stack Development",
+        "parent_id": 95
+    },
+    {
+        "id": 107,
+        "active": false,
+        "selectable": false,
+        "name": "Game Development",
+        "parent_id": 95
+    },
+    {
+        "id": 108,
+        "active": false,
+        "selectable": false,
+        "name": "Manual Testing",
+        "parent_id": 95
+    },
+    {
+        "id": 109,
+        "active": false,
+        "selectable": false,
+        "name": "Mobile App Development",
+        "parent_id": 95
+    },
+    {
+        "id": 110,
+        "active": false,
+        "selectable": false,
+        "name": "Mobile Design",
+        "parent_id": 95
+    },
+    {
+        "id": 111,
+        "active": false,
+        "selectable": false,
+        "name": "Mobile Game Development",
+        "parent_id": 95
+    },
+    {
+        "id": 112,
+        "active": false,
+        "selectable": false,
+        "name": "Prototyping",
+        "parent_id": 95
+    },
+    {
+        "id": 113,
+        "active": false,
+        "selectable": false,
+        "name": "Scripting & Automation",
+        "parent_id": 95
+    },
+    {
+        "id": 114,
+        "active": true,
+        "selectable": true,
+        "name": "Test Automation",
+        "parent_id": 95
+    },
+    {
+        "id": 115,
+        "active": false,
+        "selectable": false,
+        "name": "Web Design",
+        "parent_id": 95
+    },
+    {
+        "id": 116,
+        "active": false,
+        "selectable": false,
+        "name": "Translation",
+        "parent_id": null
+    },
+    {
+        "id": 117,
+        "active": false,
+        "selectable": false,
+        "name": "General Language Translation",
+        "parent_id": 116
+    },
+    {
+        "id": 118,
+        "active": false,
+        "selectable": false,
+        "name": "Language Localisation",
+        "parent_id": 116
+    },
+    {
+        "id": 119,
+        "active": false,
+        "selectable": false,
+        "name": "Language Tutoring",
+        "parent_id": 116
+    },
+    {
+        "id": 120,
+        "active": false,
+        "selectable": false,
+        "name": "Legal Translation",
+        "parent_id": 116
+    },
+    {
+        "id": 121,
+        "active": false,
+        "selectable": false,
+        "name": "Technical Translation",
+        "parent_id": 116
+    },
+    {
+        "id": 122,
+        "active": false,
+        "selectable": false,
+        "name": "Business Writing",
+        "parent_id": 116
+    },
+    {
+        "id": 123,
+        "active": false,
+        "selectable": false,
+        "name": "Writing",
+        "parent_id": null
+    },
+    {
+        "id": 124,
+        "active": false,
+        "selectable": false,
+        "name": "Content Writing",
+        "parent_id": 123
+    },
+    {
+        "id": 125,
+        "active": false,
+        "selectable": false,
+        "name": "Copywriting",
+        "parent_id": 123
+    },
+    {
+        "id": 126,
+        "active": false,
+        "selectable": false,
+        "name": "Creative Writing",
+        "parent_id": 123
+    },
+    {
+        "id": 127,
+        "active": false,
+        "selectable": false,
+        "name": "Editing & Proofreading",
+        "parent_id": 123
+    },
+    {
+        "id": 128,
+        "active": false,
+        "selectable": false,
+        "name": "Ghostwriting",
+        "parent_id": 123
+    },
+    {
+        "id": 129,
+        "active": false,
+        "selectable": false,
+        "name": "Grant Writing",
+        "parent_id": 123
+    },
+    {
+        "id": 130,
+        "active": false,
+        "selectable": false,
+        "name": "Scriptwriting",
+        "parent_id": 123
+    },
+    {
+        "id": 131,
+        "active": false,
+        "selectable": false,
+        "name": "Technical Writing",
+        "parent_id": 123
+    }
+]

--- a/sample_data/tag.json
+++ b/sample_data/tag.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Tag 1"
+    },
+    {
+        "name": "Tag 2"
+    },
+    {
+        "name": "Tag 3"
+    },
+    {
+        "name": "Tag 4"
+    }
+]

--- a/security/services.py
+++ b/security/services.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from security.models import OrganisationPerson, Organisation, Person
 
-from .models import User
+from .models import User, ProductOwner
 
 logger = logging.getLogger(__name__)
 
@@ -129,3 +129,12 @@ class UserService:
         except User.DoesNotExist as e:
             logger.error(f"Failed to delete User due to: {e}")
             return False
+
+
+class ProductOwnerService:
+    @staticmethod
+    def create(**kwargs):
+        product_owner = ProductOwner(**kwargs)
+        product_owner.save()
+
+        return product_owner

--- a/talent/services.py
+++ b/talent/services.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 
 
-from talent.models import Person, BountyClaim, BountyDeliveryAttempt
+from talent.models import Person, Skill, Expertise, BountyClaim, BountyDeliveryAttempt
 from security.models import User
 from product_management.models import Bounty
 
@@ -58,6 +58,24 @@ class PersonService:
         person.is_test_user = True
         person.save()
         return person
+
+
+class SkillService:
+    @staticmethod
+    def create(**kwargs):
+        skill = Skill(**kwargs)
+        skill.save()
+
+        return skill
+
+
+class ExpertiseService:
+    @staticmethod
+    def create(**kwargs):
+        expertise = Expertise(**kwargs)
+        expertise.save()
+
+        return expertise
 
 
 # TODO: This service will be deleted once ProfileService is done

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
           <div class="flex items-center justify-between">
             <a href="#" class="-m-1.5 p-1.5">
               <span class="sr-only">OpenUnited</span>
-              <img class="h-8 w-auto" src="/static/assets/images/logo.svg" alt="">
+              <img class="h-8 w-auto" src="{{ static('images/logo.svg') }}" alt="">
             </a>
             <button type="button"
               class="-m-2.5 rounded-md p-2.5 text-gray-700 focus-visible:outline-none btn-close-menu">
@@ -394,7 +394,7 @@
   <!-- https://github.com/Choices-js/Choices -->
   <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
 
-  <script type="text/javascript" src="/static/assets/scripts/main.js"></script>
+  <script type="text/javascript" src="{{ static('scripts/main.js') }}"></script>
 
 </body>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,5 @@
-{% comment %} {% set TASK_TYPES = ["Draft", "Blocked", "Available", "Claimed", "Done", "In Review"] %}
-{% set TASK_CLAIM_TYPES = ["Claimed", "Not Ready", "Ready", "Done"] %} {% endcomment %}
-{% load static %}
+{% set TASK_TYPES = ["Draft", "Blocked", "Available", "Claimed", "Done", "In Review"] %}
+{% set TASK_CLAIM_TYPES = ["Claimed", "Not Ready", "Ready", "Done"] %}
 <html>
 
 <head>
@@ -9,18 +8,9 @@
 
   <!-- tailwind version 3.3.2 -->
   <script src="https://cdn.tailwindcss.com?plugins=line-clamp"></script>
-  <!-- <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          
-        }
-      }
-    }
-  </script> -->
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
-  <link rel="stylesheet" href="{% static 'styles/styles.css' %}">
+  <link rel="stylesheet" href="{{ static('styles/styles.css') }}">
 
   <title>{% block title %}{% endblock %}</title>
 </head>
@@ -36,9 +26,9 @@
           <a href="#" class="text-sm font-semibold leading-6 text-gray-900">Explainer Video</a>
         </div>
         <div class="flex justify-start lg:justify-center grow w-full h-8 lg:inset-x-0 lg:absolute z-[1]">
-          <a href="{% url 'home' %}" class="-m-1.5 p-1.5">
+          <a href="{{ url('home') }}" class="-m-1.5 p-1.5">
             <span class="sr-only">OpenUnited</span>
-            <img class="h-8 w-auto" src="{% static 'images/logo.svg' %}" alt="OpenUnited Logo">
+            <img class="h-8 w-auto" src="{{ static('images/logo.svg') }}" alt="OpenUnited Logo">
           </a>
         </div>
         <div class="flex lg:hidden">
@@ -54,12 +44,12 @@
         <div class="hidden lg:flex lg:items-center lg:justify-end lg:gap-x-5 relative z-[2] ml-auto">
           {% if request.user.is_authenticated %}
             <span>Welcome, {{ request.user }}</span>
-            <a href="{% url 'log_out' %}"
+            <a href="{{ url('log_out') }}"
             class="text-sm font-semibold leading-6 transition-all delay-600 rounded bg-indigo-600 px-3.5 py-1.5 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Log out</a>
             {% else %}
-            <a href="{% url 'sign_in' %}" class="text-sm font-semibold leading-6 text-gray-900">Sign in <span
+            <a href="{{ url('sign_in') }}" class="text-sm font-semibold leading-6 text-gray-900">Sign in <span
               aria-hidden="true">&rarr;</span></a>
-            <a href="{% url 'sign_up' %}"
+            <a href="{{ url('sign_up') }}"
             class="text-sm font-semibold leading-6 transition-all delay-600 rounded bg-indigo-600 px-3.5 py-1.5 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign
             up</a>
           {% endif %}
@@ -69,7 +59,7 @@
       <div class="flex items-center justify-center text-sm font-medium leading-6 text-gray-600 py-4">
         <span class="mb-[3px]">Join Us on</span>
         <a href="https://discord.gg/T3xevYvWey" class="ml-2 h-6 w-auto">
-          <img class="w-full h-full" src="{% static 'images/discord-logo.png' %}" alt="Discord Logo">
+          <img class="w-full h-full" src="{{ static('images/discord-logo.png') }}" alt="Discord Logo">
         </a>
       </div>
       <div class="lg:hidden menu-wrap" role="dialog" aria-modal="true">
@@ -78,9 +68,9 @@
         <div
           class="fixed inset-y-0 z-[11] overflow-y-auto bg-white px-4 py-6 sm:max-w-sm w-full sm:ring-1 sm:ring-gray-900/10 menu">
           <div class="flex items-center justify-between">
-            <a href="{% url 'home' %}" class="-m-1.5 p-1.5">
+            <a href="#" class="-m-1.5 p-1.5">
               <span class="sr-only">OpenUnited</span>
-              <img class="h-8 w-auto" src="{% static 'images/logo.svg' %}" alt="OpenUnited Logo">
+              <img class="h-8 w-auto" src="/static/assets/images/logo.svg" alt="">
             </a>
             <button type="button"
               class="-m-2.5 rounded-md p-2.5 text-gray-700 focus-visible:outline-none btn-close-menu">
@@ -98,22 +88,16 @@
             <li class="flex">
               <a href="#" class="text-sm font-semibold leading-6 text-gray-900">Explainer Video</a>
             </li>
-            {% if request.user.is_authenticated %}
-            <span>Welcome, {{ request.user }}</span>
-            <a href="{% url 'log_out' %}"
-            class="text-sm font-semibold leading-6 transition-all delay-600 rounded bg-indigo-600 px-3.5 py-1.5 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Log out</a>
-            {% else %}
-              <li class="flex">
-                <a href="{% url 'sign_in' %}" class="text-sm font-semibold leading-6 text-gray-900">
-                  Sign in <span aria-hidden="true">&rarr;</span>
-                </a>
-              </li>
-              <li class="flex">
-                <a href="{% url 'sign_up' %}"
-                  class="text-sm font-semibold leading-6 text-gray-900 transition-all delay-600 rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign
-                  up</a>
-              </li>
-            {% endif %}
+            <li class="flex">
+              <a href="#" class="text-sm font-semibold leading-6 text-gray-900">
+                Sign in <span aria-hidden="true">&rarr;</span>
+              </a>
+            </li>
+            <li class="flex">
+              <a href="#"
+                class="text-sm font-semibold leading-6 text-gray-900 transition-all delay-600 rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign
+                up</a>
+            </li>
           </ul>
         </div>
       </div>
@@ -410,7 +394,7 @@
   <!-- https://github.com/Choices-js/Choices -->
   <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
 
-  <script type="text/javascript" src="{% static 'scripts/main.js' %}"></script>
+  <script type="text/javascript" src="/static/assets/scripts/main.js"></script>
 
 </body>
 


### PR DESCRIPTION
This PR contains the code that:

* sets up Jinja2 as the default template engine
* refactors `load_sample_data.py` for generating sample data
* partially implements challenges view

Some notes:

* There are sample json data in the PR, so that is why it has many changes.
* I am aware of the repetition of the service files' `create` method. I will find a better way to achieve the same thing without repetition.
* I commented-out some of the service files' `create` methods. I will replace them with the new methods.
* I did not translate sign up and sign in views' template files to Jinja syntax because the UX designer might come up with a different UI. Therefore, sign in and sign up views throw error at the moment. If we agree on keeping this UI, I will translate the necessary parts ASAP.