### PR TITLE
Use whitenoise to serve static files

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,11 @@ echo "Apply database migrations"
 echo "----------------------------------------------------------"
 nohup python manage.py migrate --run-syncdb
 
+# Prepare static files
+echo "Preparing static files"
+echo "----------------------------------------------------------"
+nohup python manage.py collectstatic
+
 # Load Sample Data
 # echo "Load Sample Data"
 # echo "----------------------------------------------------------"

--- a/openunited/settings/production.py
+++ b/openunited/settings/production.py
@@ -19,3 +19,15 @@ EMAIL_USE_SSL = False
 
 # When running in a DigitalOcean app, Django sits behind a proxy
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,3 +112,4 @@ watchfiles==0.19.0
 wcwidth==0.2.6
 websockets==11.0.3
 xlwt==1.3.0
+whitenoise==6.6.0


### PR DESCRIPTION
Django only serves static files when DEBUG is enabled. Whitenoise is a good option for serving static files in a production environment.