### PR TITLE
Preproduction Github actions

### DIFF
--- a/.github/assets/preproduction.yaml
+++ b/.github/assets/preproduction.yaml
@@ -1,0 +1,60 @@
+alerts:
+- rule: DEPLOYMENT_FAILED
+- rule: DOMAIN_FAILED
+databases:
+- engine: PG
+  name: openunited-core-db
+  version: "12"
+domains:
+- domain: preproduction.openunited.com
+  type: PRIMARY
+features:
+- buildpack-stack=ubuntu-22
+ingress:
+  rules:
+  - component:
+      name: platform
+    match:
+      path:
+        prefix: /
+name: openunited-platform-preprod
+region: sfo
+services:
+- envs:
+  - key: POSTGRES_HOST
+    scope: RUN_AND_BUILD_TIME
+    value: ${openunited-core-db.HOSTNAME}
+  - key: PORT
+    scope: RUN_AND_BUILD_TIME
+    value: "80"
+  - key: POSTGRES_DB
+    scope: RUN_AND_BUILD_TIME
+    value: ${openunited-core-db.DATABASE}
+  - key: POSTGRES_USER
+    scope: RUN_AND_BUILD_TIME
+    value: ${openunited-core-db.USERNAME}
+  - key: POSTGRES_PORT
+    scope: RUN_AND_BUILD_TIME
+    value: ${openunited-core-db.PORT}
+  - key: POSTGRES_PASSWORD
+    scope: RUN_AND_BUILD_TIME
+    value: ${openunited-core-db.PASSWORD}
+  - key: DJANGO_SETTINGS_MODULE
+    scope: RUN_AND_BUILD_TIME
+    value: openunited.settings.development
+  - key: DJANGO_ALLOWED_HOSTS
+    scope: RUN_AND_BUILD_TIME
+    value: preproduction.openunited.com
+  - key: DJANGO_SECRET_KEY
+    scope: RUN_AND_BUILD_TIME
+    type: SECRET
+    value: 862ec1becf292bf2d001
+  http_port: 80
+  image:
+    deploy_on_push: {}
+    registry_type: DOCR
+    repository: core
+    tag: 0.1.0
+  instance_count: 1
+  instance_size_slug: basic-xxs
+  name: platform

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -1,0 +1,41 @@
+name: Deploy to Pre-production
+
+on:
+  push:
+    branches: [ "preproduction" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Update the project version
+      run: pip install python-semantic-release && python -m semantic_release version
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    - name: Build the Docker image
+      run: |
+        export VERSION=hotfix-$(python -c 'import version; print(version.version)')
+        echo "VERSION is $VERSION"
+        docker build . --file Dockerfile --tag registry.digitalocean.com/openunited/core:$VERSION
+    - name: Login to registry
+      run: doctl registry login --expiry-seconds 600
+    - name: Push to DigitalOcean
+      run: docker push -a registry.digitalocean.com/openunited/core
+    - name: Create or update preproduction app
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      run: |
+        cp .github/assets/preproduction.yaml spec.yaml
+
+        export VERSION=hotfix-$(python -c 'import version; print(version.version)')
+        sed -i "s/\(.*tag: \).*/\1$VERSION/" spec.yaml
+
+        doctl --output json apps create --project-id cff8852f-36fa-430d-9e74-627a3723a4be --upsert --spec spec.yaml

--- a/.github/workflows/delete-preprodution.yaml
+++ b/.github/workflows/delete-preprodution.yaml
@@ -1,0 +1,16 @@
+name: Preproduction branch deleted
+on: delete
+jobs:
+  delete:
+    if: github.event.ref_type == 'branch' && github.event.ref == 'preproduction'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - name: Delete preproduction app
+      run: |
+        wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 && chmod +x jq
+        export APP_ID="$(doctl --output json apps list | ./jq -r 'map(select(.spec.name == "openunited-platform-preprod")) | .[0].id')"
+        doctl apps delete --force "$APP_ID"

--- a/.github/workflows/deploy-preprod-to-prod.yml
+++ b/.github/workflows/deploy-preprod-to-prod.yml
@@ -1,0 +1,36 @@
+name: Deploy to Production and Demo
+
+on:
+  - workflow_dispatch
+
+env:
+  PRODUCTION_ID: c3364f4f-1d34-4b31-ac49-da9782159a7e
+  DEMO_ID: c87ff841-b900-4cc7-b3ea-19d29948be6e
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - uses: actions/setup-python@v4
+    - run: pip install yq
+    - name: Fetch spec files
+      run: |
+        wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 && chmod +x jq
+        export PREPRODUCTION_ID="$(doctl --output json apps list | ./jq -r 'map(select(.spec.name == "openunited-platform-preprod")) | .[0].id')"
+        doctl apps spec get $PREPRODUCTION_ID > preproduction.yaml
+        doctl apps spec get $PRODUCTION_ID > production.yaml
+        doctl apps spec get $DEMO_ID > demo.yaml
+    - name: Update image tag
+      run: |
+        export TAG="$(python -m yq -r .services[0].image.tag preproduction.yaml)"
+        echo "Updating production image tag to $TAG"
+        python -m yq -Y --indentless --arg TAG "$TAG" --in-place '.services[0].image.tag = $TAG' production.yaml
+        python -m yq -Y --indentless --arg TAG "$TAG" --in-place '.services[0].image.tag = $TAG' demo.yaml
+    - name: Update the environments
+      run: |
+        doctl apps update $PRODUCTION_ID --spec production.yaml
+        doctl apps update $DEMO_ID --spec demo.yaml


### PR DESCRIPTION
Adds three Github Actions:
- When a commit is pushed to the `preproduction` branch, a docker container will be built, and a DigitalOcean App for preproduction.openunited.com will be created (if it doesn't exist) or updated to use the new container.
- Adds a new manual Action to deploy the container in preproduction to production
- When the `preproduction` branch is deleted, the DigitalOcean App is also deleted

This allows for hotfix PRs to be tested and deployed to production even if staging is further ahead.