### PR TITLE
Fixed user authentication details in mobile navbar

### DIFF
--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -109,25 +109,72 @@
                 </svg>
             </button>
         </div>
-        <ul class="space-y-5 flex flex-col pt-20 sm:pt-[30%] pb-10">
+           
+        {% if  request.user.is_authenticated %}
+        {% set person = request.user.person %}
+            <div>
+                <div class=" group w-full rounded-md px-3.5 py-2 text-left text-sm font-medium
+                            text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-purple-500
+                            focus:ring-offset-2 focus:ring-offset-gray-100" id="navbar-menu-button"
+                    aria-expanded="false" aria-haspopup="true">
+                    <span class="flex w-full items-center justify-between">
+                        <span class="flex min-w-0 items-center justify-between space-x-3">
+                            {% set photo_url, _ = person.get_photo_url() %}
+                            <img class="h-10 w-10 flex-shrink-0 rounded-full bg-gray-300" src="{{ photo_url }}"
+                                alt="Profile Picture">
+                            <span class="flex min-w-0 flex-1 flex-col">
+                                <span
+                                    class="truncate text-sm font-medium text-gray-900">{{ person.get_full_name() }}</span>
+                                <span class="truncate text-sm text-gray-500">@{{ person.get_username() }}</span>
+                            </span>
+                        </span>
+                      
+                    </span>
+                </div>
+            </div>
+
+            <div class="py-1" role="none">
+                <a href="{{ url('dashboard') }}" class="text-gray-700 block px-4 py-2 text-sm" role="menuitem"
+                    tabindex="-1" id="options-menu-item-0">Dashboard</a>
+                <a href="{{ url('profile', args=(request.user.person.pk,) ) }}"
+                    class="text-gray-700 block px-4 py-2 text-sm" role="menuitem" tabindex="-1"
+                    id="options-menu-item-1">Your Profile</a>
+                <a href="{{ url('portfolio', args=(request.user.username,) ) }}"
+                    class="text-gray-700 block px-4 py-2 text-sm" role="menuitem" tabindex="-1"
+                    id="options-menu-item-2">Visit Portfolio</a>
+            </div>
+            <div class="py-1" role="none">
+                <a href="{{ url('log_out') }}" class="text-gray-700 block px-4 py-2 text-sm" role="menuitem"
+                    tabindex="-1" id="options-menu-item-5">Logout</a>
+            </div>
+
+            {% endif %}
+
+            <ul class="space-y-5 flex flex-col pt-4 sm:pt-[30%] pb-10">
+
             <li class="flex">
                 <a href="{{ url('challenges') }}" class="text-sm font-semibold leading-6 text-gray-900">Find a
                     Challenge</a>
-            </li>
-            <li class="flex">
-                <a href="#" class="text-sm font-semibold leading-6 text-gray-900">Explainer Video</a>
-            </li>
-            <li class="flex">
-                <a href="{{ url('sign_in') }}" class="text-sm font-semibold leading-6 text-gray-900">
-                    Sign in <span aria-hidden="true">&rarr;</span>
-                </a>
-            </li>
-            <li class="flex">
-                <a href="{{ url('sign-up') }}"
-                    class="text-sm font-semibold leading-6 text-gray-900 transition-all delay-600 rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-                    Sign up
-                </a>
-            </li>
+                </li>
+                <li class="flex">
+                    <a href="#" class="text-sm font-semibold leading-6 text-gray-900">Explainer Video</a>
+                </li>
+                
+
+            {% if not request.user.is_authenticated %}
+                <li class="flex">
+                    <a href="{{ url('sign_in') }}" class="text-sm font-semibold leading-6 text-gray-900">
+                        Sign in <span aria-hidden="true">&rarr;</span>
+                    </a>
+                </li>
+                <li class="flex">
+                    <a href="{{ url('sign-up') }}"
+                        class="text-sm font-semibold leading-6 text-gray-900 transition-all delay-600 rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                        Sign up
+                    </a>
+                </li>
+            {% endif %}
+
         </ul>
     </div>
 </nav>


### PR DESCRIPTION
Whether the user has logged in or not, the mobile navbar always shows the "Sign In" and "Sign Up" .

The commit fixes this.

It shows the details correctly if the user has logged in or not. 

Attaching the "before" and "after" screenshots

### Before Fix

![before-fix](https://github.com/OpenUnited/platform/assets/62328681/20c8dccc-38e8-45fa-90d7-ec5c76de708a)


### After Fix

![after-fix](https://github.com/OpenUnited/platform/assets/62328681/c21454c7-58da-4da3-be35-bec5672953d5)
