### PR TITLE
Load Sentry DSN from environment

### DIFF
--- a/openunited/settings/production.py
+++ b/openunited/settings/production.py
@@ -57,9 +57,10 @@ LOGGING = {
     },
 }
 
-sentry_sdk.init(
-    dsn="https://34dd2db529445f60bd209e142e98af22@o1120097.ingest.sentry.io/4506064626909184",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-)
+if os.environ.get("SENTRY_DSN"):
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+    )


### PR DESCRIPTION
Hardcoding the value in the codebase meant everyone using the production settings would get their info sent to the same Sentry account. 