### PR TITLE
Added profile picture preview on successful upload

### DIFF
--- a/talent/templates/talent/profile_picture.html
+++ b/talent/templates/talent/profile_picture.html
@@ -4,8 +4,7 @@
         style="background-image: url('{{ photo_url }}')">
     </div>
         <img id="image-preview" src="" alt="Image Preview" 
-        class="w-40 h-40 flex items-center justify-center rounded-full bg-no-repeat bg-center bg-cover"
-        style="display: none;" />
+        class="w-40 h-40 flex items-center justify-center rounded-full bg-no-repeat bg-center bg-cover hidden" />
     <div class="flex flex-col items-center">
         {% if requires_upload %}
         <label for="{{ form.photo.id_for_label }}"
@@ -78,7 +77,7 @@ document.querySelector("#id_photo").addEventListener("change", function (e) {
 
         reader.onload = function (event) {
             imagePreview.src = event.target.result
-            imagePreview.style.display = "block"
+            imagePreview.classList.remove("hidden")
             placeholder.style.display = "none"
             if (removeButton) {
                 removeButton.style.display = "none"

--- a/talent/templates/talent/profile_picture.html
+++ b/talent/templates/talent/profile_picture.html
@@ -1,8 +1,11 @@
 <div id="profile-picture" class="flex items-center shrink-0 flex-col lg:w-[244px]">
-    <div id="profile-picture"
+    <div id="profile-picture-placeholder"
         class="w-40 h-40 flex items-center justify-center rounded-full bg-no-repeat bg-center bg-cover"
         style="background-image: url('{{ photo_url }}')">
     </div>
+        <img id="image-preview" src="" alt="Image Preview" 
+        class="w-40 h-40 flex items-center justify-center rounded-full bg-no-repeat bg-center bg-cover"
+        style="display: none;" />
     <div class="flex flex-col items-center">
         {% if requires_upload %}
         <label for="{{ form.photo.id_for_label }}"
@@ -44,7 +47,7 @@
                 Upload
             </label>
 
-            <label for="remove_picture_button"
+            <label for="remove_picture_button" id="label_remove_picture_button"
                 class="mt-4 appearance-none inline-flex items-center w-full sm:w-fit bg-white text-sm font-semibold leading-6 transition-all delay-600 rounded px-2.5 md:px-3.5 py-1.5 text-gray-900 shadow-sm hover:bg-gray-900/[0.8] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-transparent cursor-pointer border border-solid border-[#ddd] hover:border-gray-900/[0.8]">
                 <input id="remove_picture_button" type="submit" hx-get="{{ url('profile', args=(pk,)) }}" hx-target="#profile-picture" hx-confirm="Are you sure to remove the picture?"
                     class="hidden appearance-none inline-flex items-center w-full sm:w-fit bg-white text-sm font-semibold leading-6 transition-all delay-600 rounded px-2.5 md:px-3.5 py-1.5 text-gray-900 shadow-sm hover:bg-gray-900/[0.8] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-transparent cursor-pointer border border-solid border-[#ddd] hover:border-gray-900/[0.8]">
@@ -61,3 +64,32 @@
         {% endif %}
     </div>
 </div>
+
+<script>
+document.querySelector("#id_photo").addEventListener("change", function (e) {
+    const fileInput = e.target
+
+    const imagePreview = document.getElementById("image-preview")
+    const placeholder = document.getElementById("profile-picture-placeholder")
+    const removeButton = document.getElementById("label_remove_picture_button")
+
+    if (fileInput.files && fileInput.files[0]) {
+        const reader = new FileReader()
+
+        reader.onload = function (event) {
+            imagePreview.src = event.target.result
+            imagePreview.style.display = "block"
+            placeholder.style.display = "none"
+            if (removeButton) {
+                removeButton.style.display = "none"
+            }
+        }
+
+        reader.readAsDataURL(fileInput.files[0])
+    } else {
+        imagePreview.src = ""
+        imagePreview.style.display = "none"
+    }
+})
+
+</script>


### PR DESCRIPTION

### Background
- In the user profile page, when a user uploads his profile picture, there is no preview of the uploaded picture. The user is not sure whether the upload is success or not. The uploaded profile picture is getting saved on submit though.

#### Demo
![before-fix](https://github.com/OpenUnited/platform/assets/62328681/534a0d0b-229b-4b82-a10f-a397bb99cab3)


### Solution
- Add an image preview element in the html ( which is not displayed by default ) , but will be visible with the last uploaded image when the image upload is success

*Note :* 
- As per this solution, the `Remove Button` is hidden when user uploads a new picture, to avoid confusion. He can upload a new image to change the first uploaded image.
- The button is shown until he changes the original profile picture.
- Another observation is that, currently in the update profile page, we don't have a way to revert any unsaved text changes, unless he refreshes the page. Something like a `Cancel` button is a potential solution.
- The functionality of the `Remove Button` which deletes the original picture is retained.


### Changes
- `talent/templates/talent/profile_picture.html`



### Testing after fix
![after-fix](https://github.com/OpenUnited/platform/assets/62328681/5dd1f2c3-a4df-4e73-88f4-142190a0f295)