### PR TITLE
Automatically backup DB to S3

### DIFF
--- a/digitalocean-functions/packages/openunited-platform/trigger-backup.py
+++ b/digitalocean-functions/packages/openunited-platform/trigger-backup.py
@@ -1,0 +1,18 @@
+import os
+import logging
+import requests
+
+
+logger = logging.getLogger("trigger-backup")
+
+
+def main(event, context):
+    url = os.environ["BACKUP_WEBHOOK_URL"]
+    api_key = os.environ["BACKUP_WEBHOOK_KEY"]
+    response = requests.post(url, headers={"X-API-KEY": api_key})
+    logger.info("Response status: %s\nContent: %s\n", response.status_code, response.content)
+    return {
+        "body": {
+            "status_code": response.status_code
+        }
+    }

--- a/digitalocean-functions/project.yml
+++ b/digitalocean-functions/project.yml
@@ -1,0 +1,15 @@
+environment:
+  BACKUP_WEBHOOK_URL: https://openunited.com/backup/start/
+  BACKUP_WEBHOOK_KEY: "${BACKUP_WEBHOOK_KEY}"
+packages:
+    - name: openunited-platform
+      shared: false
+      functions:
+        - name: trigger-backup
+          runtime: python:3.11
+          web: false
+          triggers:
+          - name: trigger-backup
+            sourceType: scheduler
+            sourceDetails:
+              cron: "5 4 * * *"

--- a/openunited/settings/base.py
+++ b/openunited/settings/base.py
@@ -26,7 +26,10 @@ INSTALLED_APPS = [
     "django_jinja",
     "formtools",
     "debug_toolbar",
+    'dbbackup',
+    "openunited_backup",
 ]
+
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -109,6 +112,15 @@ DATABASES = {
         "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
+
+if os.environ.get("DBBACKUP_BUCKET"):
+    DBBACKUP_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    DBBACKUP_STORAGE_OPTIONS = {
+        'access_key': os.environ.get("DBBACKUP_ACCESS_KEY"),
+        'secret_key': os.environ.get("DBBACKUP_SECRET_KEY"),
+        'bucket_name': os.environ.get("DBBACKUP_BUCKET"),
+        'default_acl': 'private',
+    }
 
 AUTH_USER_MODEL = "security.User"
 

--- a/openunited/urls.py
+++ b/openunited/urls.py
@@ -27,6 +27,7 @@ urlpatterns += [
     path("talent/", include("talent.urls")),
     path("", include("security.urls")),
     path("", include("product_management.urls")),
+    path("backup/", include("openunited_backup.urls")),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/openunited_backup/apps.py
+++ b/openunited_backup/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class BackupConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "openunited_backup"

--- a/openunited_backup/urls.py
+++ b/openunited_backup/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import start_backup
+
+
+urlpatterns = [
+    path("start/", start_backup, name="start_backup"),
+]

--- a/openunited_backup/views.py
+++ b/openunited_backup/views.py
@@ -1,0 +1,21 @@
+import os
+from multiprocessing import Process
+
+from django.core import management
+from django.http import HttpResponse, HttpResponseServerError, HttpResponseForbidden
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+
+API_KEY = os.environ.get("BACKUP_WEBHOOK_KEY")
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def start_backup(request):
+    if not API_KEY:
+        return HttpResponseServerError()
+    elif API_KEY != request.META.get("HTTP_X_API_KEY"):
+        return HttpResponseForbidden()
+    Process(target=management.call_command, args=('dbbackup',)).start()
+    return HttpResponse("Backup started")

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,3 +113,4 @@ wcwidth==0.2.6
 websockets==11.0.3
 xlwt==1.3.0
 whitenoise==6.6.0
+django-dbbackup==4.0.2


### PR DESCRIPTION
Adds a tiny django app that backups up the DB to S3 when a certain endpoint (`/backup/start/`) is called. Also adds a scheduled DigitalOcean Function that is triggered every night and calls that endpoint.

Besides merging this PR, the S3 access keys and bucket name must be configured in the DO App environment.