### PR TITLE
Set current version to 2.0.0

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-version = "0.5.2"
+version = "2.0.0"


### PR DESCRIPTION
This commit (and a tag `v2.0.0` that will pushed after it's merged) will mark the current version of the project as 2.0.0.

It was produced by running `semantic-release version --major` twice - once to get to 1.0, another to get to 2.0 - then deleting the 1.0 commit.