### PR TITLE
Fix CSRF error in staging and demo

### DIFF
--- a/openunited/settings/base.py
+++ b/openunited/settings/base.py
@@ -96,6 +96,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "openunited.wsgi.application"
 
+# When running in a DigitalOcean app, Django sits behind a proxy
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/openunited/settings/production.py
+++ b/openunited/settings/production.py
@@ -21,9 +21,6 @@ EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
 DEFAULT_FROM_EMAIL = "no-reply@openunited.com"
 
-# When running in a DigitalOcean app, Django sits behind a proxy
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",


### PR DESCRIPTION
The SECURE_PROXY_SSL_HEADER setting should be applied to all environments, since they all sit behind proxies.