### PR TITLE
Fix duplicated https:// in URLs

### DIFF
--- a/openunited/settings/base.py
+++ b/openunited/settings/base.py
@@ -164,9 +164,9 @@ if os.getenv("AWS_STORAGE_BUCKET_NAME"):
     STATICFILES_DIRS = [
         os.path.join(BASE_DIR, "static"),
     ]
-    STATIC_URL = "https://%s/%s/" % (AWS_S3_ENDPOINT_URL, AWS_STATIC_LOCATION)
+    STATIC_URL = "%s/%s/" % (AWS_S3_ENDPOINT_URL, AWS_STATIC_LOCATION)
     STATICFILES_STORAGE = "openunited.storage_backends.StaticStorage"
-    MEDIA_URL = "https://%s/%s/" % (AWS_S3_ENDPOINT_URL, AWS_MEDIA_LOCATION)
+    MEDIA_URL = "%s/%s/" % (AWS_S3_ENDPOINT_URL, AWS_MEDIA_LOCATION)
     DEFAULT_FILE_STORAGE = "openunited.storage_backends.PublicMediaStorage"
 else:
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")


### PR DESCRIPTION
The variable AWS_S3_ENDPOINT_URL already contains https://, so we shouldn't add it again in STATIC_URL and MEDIA_URL.