### PR TITLE
Display error for a second bounty creation for the same challenge

### DIFF
--- a/product_management/templates/product_management/forms/bounty_form.html
+++ b/product_management/templates/product_management/forms/bounty_form.html
@@ -28,6 +28,13 @@
                     <div class="mt-2">
                         {{ form.challenge }}
                     </div>
+                    {% if form.errors.challenge %}
+                    <div>
+                        {% for error in form.errors.challenge %}
+                        <p class="mt-2 text-sm text-red-600">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
                 </div>
 
 


### PR DESCRIPTION
- Currently, if a user creates a second bounty for the same challenge, there is no error displayed on the frontend. This PR fixes that. It shows the error now.

**Before fix**
![before-fix](https://github.com/OpenUnited/platform/assets/62328681/87305e48-8179-40ec-8e24-7a7eece72542)


**After fix**
![after-fix](https://github.com/OpenUnited/platform/assets/62328681/ac5aed41-5711-4a66-91d7-04b5f71b2577)

