### PR TITLE
Filter the Completed Challenges in Challenge List view

### DIFF
--- a/product_management/views.py
+++ b/product_management/views.py
@@ -64,6 +64,9 @@ class ChallengeListView(ListView):
         response = super().get(request, *args, **kwargs)
 
         return response
+    
+    def get_queryset(self):
+        return Challenge.objects.exclude(status=Challenge.CHALLENGE_STATUS_DONE)
 
 
 class ProductListView(ListView):


### PR DESCRIPTION
- This PR fixes the issue #129 - Dont display challenges with `Done` status in the Challenges List view


### Changes
- Added a filter to exclude challenges with status as `Done` 


### Testing
- tested and verified in the UI



**Unrelated note** : @dogukanteber, going forward to prevent wastage of efforts, 
- should I request to assign an issue to me 
- OR can I  claim the issue I am working on & start working on it ?

