### PR TITLE
Modify the tests for the signup page

### DIFF
--- a/security/tests/test_forms.py
+++ b/security/tests/test_forms.py
@@ -4,163 +4,164 @@ from django.forms import ValidationError
 from security.models import SignUpRequest
 from security.forms import SignUpStepOneForm, SignUpStepTwoForm, SignUpStepThreeForm
 from .factories import UserFactory
+from security.constants import SIGN_UP_REQUEST_ID
 
 
-# class SignUpStepOneFormTest(TestCase):
-#     def setUp(self):
-#         self.user = UserFactory(
-#             username="john", password="12345", email="user@example.com"
-#         )
+class SignUpStepOneFormTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory(
+            username="john", password="12345", email="user@example.com"
+        )
 
-#     def test_valid_email(self):
-#         form_data = {
-#             "full_name": "john doe",
-#             "preferred_name": "john",
-#             "email": "does_not_exist@example.com",
-#         }
+    def test_valid_email(self):
+        form_data = {
+            "full_name": "john doe",
+            "preferred_name": "john",
+            "email": "does_not_exist@example.com",
+        }
 
-#         form = SignUpStepOneForm(data=form_data)
-#         self.assertTrue(form.is_valid())
+        form = SignUpStepOneForm(data=form_data)
+        self.assertTrue(form.is_valid())
 
-#     def test_invalid_email(self):
-#         form_data = {
-#             "full_name": "john doe",
-#             "preferred_name": "john",
-#             "email": "user@example.com",
-#         }
+    def test_invalid_email(self):
+        form_data = {
+            "full_name": "john doe",
+            "preferred_name": "john",
+            "email": "user@example.com",
+        }
 
-#         form = SignUpStepOneForm(data=form_data)
-#         self.assertFalse(form.is_valid())
+        form = SignUpStepOneForm(data=form_data)
+        self.assertFalse(form.is_valid())
 
-#     def test_invalid_clean(self):
-#         email = "john@example.com"
-#         _ = UserFactory(email=email)
-#         form_data = {
-#             "full_name": "john doe",
-#             "preferred_name": "john",
-#             "email": email,
-#         }
+    def test_invalid_clean(self):
+        email = "john@example.com"
+        _ = UserFactory(email=email)
+        form_data = {
+            "full_name": "john doe",
+            "preferred_name": "john",
+            "email": email,
+        }
 
-#         form = SignUpStepOneForm(data=form_data)
+        form = SignUpStepOneForm(data=form_data)
 
-#         self.assertFalse(form.is_valid())
-#         self.assertIsNotNone(form.errors)
+        self.assertFalse(form.is_valid())
+        self.assertIsNotNone(form.errors)
 
-#         cleaned_email = form.clean_email()
-#         self.assertIsNone(cleaned_email)
+        cleaned_email = form.clean_email()
+        self.assertIsNone(cleaned_email)
 
-#         expected_error_message = "That email isn't available, please try another"
-#         self.assertIn(expected_error_message, form.errors.get("email", []))
+        expected_error_message = "That email isn't available, please try another"
+        self.assertIn(expected_error_message, form.errors.get("email", []))
 
-#     def test_valid_clean(self):
-#         _ = UserFactory(email="john@example.com")
-#         email = "not_john@example.com"
-#         form_data = {
-#             "full_name": "john doe",
-#             "preferred_name": "john",
-#             "email": email,
-#         }
+    def test_valid_clean(self):
+        _ = UserFactory(email="john@example.com")
+        email = "not_john@example.com"
+        form_data = {
+            "full_name": "john doe",
+            "preferred_name": "john",
+            "email": email,
+        }
 
-#         form = SignUpStepOneForm(data=form_data)
+        form = SignUpStepOneForm(data=form_data)
 
-#         self.assertTrue(form.is_valid())
-#         cleaned_email = form.clean_email()
+        self.assertTrue(form.is_valid())
+        cleaned_email = form.clean_email()
 
-#         self.assertEqual(email, cleaned_email)
-
-
-# class SignUpStepTwoFormTest(TestCase):
-#     def setUp(self):
-#         self.signup_request = SignUpRequest.objects.create(verification_code="123456")
-
-#     def test_missing_verification_code(self):
-#         form_data = {
-#             "verification_code": "",
-#         }
-#         form = SignUpStepTwoForm(
-#             data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-#         )
-
-#         self.assertFalse(form.is_valid())
-
-#     def test_clean_method_invalid_verification_code(self):
-#         form_data = {
-#             "verification_code": "654321",
-#         }
-#         form = SignUpStepTwoForm(
-#             data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-#         )
-
-#         self.assertFalse(form.is_valid())
-#         with self.assertRaises(ValidationError):
-#             form.clean()
-
-#     def test_clean_method_valid_verification_code(self):
-#         form_data = {
-#             "verification_code": "123456",
-#         }
-#         form = SignUpStepTwoForm(
-#             data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-#         )
-
-#         self.assertTrue(form.is_valid())
-#         form.clean()
+        self.assertEqual(email, cleaned_email)
 
 
-# class SignUpStepThreeFormTest(TestCase):
-#     def test_valid_clean_username(self):
-#         _ = UserFactory(username="test_user")
-#         form_data = {
-#             "username": "does_not_exit",
-#             "password": "vvFTtNOWcBEKILA",
-#             "password_confirm": "vvFTtNOWcBEKILA",
-#         }
+class SignUpStepTwoFormTest(TestCase):
+    def setUp(self):
+        self.signup_request = SignUpRequest.objects.create(verification_code="123456")
 
-#         form = SignUpStepThreeForm(data=form_data)
+    def test_missing_verification_code(self):
+        form_data = {
+            "verification_code": "",
+        }
+        form = SignUpStepTwoForm(
+            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
+        )
 
-#         self.assertTrue(form.is_valid())
+        self.assertFalse(form.is_valid())
 
-#         cleaned_username = form.clean_username()
-#         self.assertEqual(cleaned_username, "does_not_exit")
+    def test_clean_method_invalid_verification_code(self):
+        form_data = {
+            "verification_code": "654321",
+        }
+        form = SignUpStepTwoForm(
+            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
+        )
 
-#     def test_invalid_clean_username(self):
-#         _ = UserFactory(username="test_user")
-#         form_data = {
-#             "username": "test_user",
-#             "password": "vvFTtNOWcBEKILA",
-#             "password_confirm": "vvFTtNOWcBEKILA",
-#         }
+        self.assertFalse(form.is_valid())
+        with self.assertRaises(ValidationError):
+            form.clean()
 
-#         form = SignUpStepThreeForm(data=form_data)
+    def test_clean_method_valid_verification_code(self):
+        form_data = {
+            "verification_code": "123456",
+        }
+        form = SignUpStepTwoForm(
+            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
+        )
 
-#         self.assertFalse(form.is_valid())
+        self.assertTrue(form.is_valid())
+        form.clean()
 
-#         cleaned_username = form.clean_username()
-#         self.assertIsNone(cleaned_username)
 
-#         expected_error = "Username is already exist"
-#         self.assertIn(expected_error, form.errors.get("username"), [])
+class SignUpStepThreeFormTest(TestCase):
+    def test_valid_clean_username(self):
+        _ = UserFactory(username="test_user")
+        form_data = {
+            "username": "does_not_exit",
+            "password": "vvFTtNOWcBEKILA",
+            "password_confirm": "vvFTtNOWcBEKILA",
+        }
 
-#     def test_valid_clean(self):
-#         form_data = {
-#             "username": "test_user",
-#             "password": "vvFTtNOWcBEKILA",
-#             "password_confirm": "vvFTtNOWcBEKILA",
-#         }
+        form = SignUpStepThreeForm(data=form_data)
 
-#         form = SignUpStepThreeForm(data=form_data)
+        self.assertTrue(form.is_valid())
 
-#         self.assertTrue(form.is_valid())
+        cleaned_username = form.clean_username()
+        self.assertEqual(cleaned_username, "does_not_exit")
 
-#     def test_invalid_clean(self):
-#         form_data = {
-#             "username": "test_user",
-#             "password": "vvFTtNOWcBEKILA",
-#             "password_confirm": "vvFTtNOWcBEKILA111",
-#         }
+    def test_invalid_clean_username(self):
+        _ = UserFactory(username="test_user")
+        form_data = {
+            "username": "test_user",
+            "password": "vvFTtNOWcBEKILA",
+            "password_confirm": "vvFTtNOWcBEKILA",
+        }
 
-#         form = SignUpStepThreeForm(data=form_data)
+        form = SignUpStepThreeForm(data=form_data)
 
-#         self.assertFalse(form.is_valid())
-#         with self.assertRaises(ValidationError):
-#             form.clean()
+        self.assertFalse(form.is_valid())
+
+        cleaned_username = form.clean_username()
+        self.assertIsNone(cleaned_username)
+
+        expected_error = "Username is already exist"
+        self.assertIn(expected_error, form.errors.get("username"), [])
+
+    def test_valid_clean(self):
+        form_data = {
+            "username": "test_user",
+            "password": "vvFTtNOWcBEKILA",
+            "password_confirm": "vvFTtNOWcBEKILA",
+        }
+
+        form = SignUpStepThreeForm(data=form_data)
+
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_clean(self):
+        form_data = {
+            "username": "test_user",
+            "password": "vvFTtNOWcBEKILA",
+            "password_confirm": "vvFTtNOWcBEKILA111",
+        }
+
+        form = SignUpStepThreeForm(data=form_data)
+
+        self.assertFalse(form.is_valid())
+        with self.assertRaises(ValidationError):
+            form.clean()

--- a/security/tests/test_forms.py
+++ b/security/tests/test_forms.py
@@ -1,10 +1,8 @@
 from django.test import TestCase
 from django.forms import ValidationError
 
-from security.models import SignUpRequest
-from security.forms import SignUpStepOneForm, SignUpStepTwoForm, SignUpStepThreeForm
+from security.forms import SignUpStepOneForm, SignUpStepThreeForm
 from .factories import UserFactory
-from security.constants import SIGN_UP_REQUEST_ID
 
 
 class SignUpStepOneFormTest(TestCase):
@@ -68,44 +66,6 @@ class SignUpStepOneFormTest(TestCase):
         cleaned_email = form.clean_email()
 
         self.assertEqual(email, cleaned_email)
-
-
-class SignUpStepTwoFormTest(TestCase):
-    def setUp(self):
-        self.signup_request = SignUpRequest.objects.create(verification_code="123456")
-
-    def test_missing_verification_code(self):
-        form_data = {
-            "verification_code": "",
-        }
-        form = SignUpStepTwoForm(
-            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-        )
-
-        self.assertFalse(form.is_valid())
-
-    def test_clean_method_invalid_verification_code(self):
-        form_data = {
-            "verification_code": "654321",
-        }
-        form = SignUpStepTwoForm(
-            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-        )
-
-        self.assertFalse(form.is_valid())
-        with self.assertRaises(ValidationError):
-            form.clean()
-
-    def test_clean_method_valid_verification_code(self):
-        form_data = {
-            "verification_code": "123456",
-        }
-        form = SignUpStepTwoForm(
-            data=form_data, initial={SIGN_UP_REQUEST_ID: self.signup_request.id}
-        )
-
-        self.assertTrue(form.is_valid())
-        form.clean()
 
 
 class SignUpStepThreeFormTest(TestCase):

--- a/security/tests/test_forms.py
+++ b/security/tests/test_forms.py
@@ -99,7 +99,7 @@ class SignUpStepThreeFormTest(TestCase):
         cleaned_username = form.clean_username()
         self.assertIsNone(cleaned_username)
 
-        expected_error = "Username is already exist"
+        expected_error = "Username already exists"
         self.assertIn(expected_error, form.errors.get("username"), [])
 
     def test_valid_clean(self):

--- a/security/tests/test_views.py
+++ b/security/tests/test_views.py
@@ -2,59 +2,60 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth.hashers import make_password
 
+from security.constants import SIGN_UP_REQUEST_ID
 from .factories import UserFactory
 
 
-# class SignUpViewTest(TestCase):
-#     def setUp(self):
-#         self.url = reverse("sign-up")
-#         self.client = Client()
+class SignUpViewTest(TestCase):
+    def setUp(self):
+        self.url = reverse("sign-up")
+        self.client = Client()
 
-#     def test_done(self):
-#         response = self.client.get(self.url)
+    def test_done(self):
+        response = self.client.get(self.url)
 
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-#         form_one = {
-#             "0-full_name": "John Doe",
-#             "0-email": "testuser@example.com",
-#             "0-preferred_name": "John",
-#             "sign_up_wizard-current_step": "0",
-#         }
+        form_one = {
+            "0-full_name": "John Doe",
+            "0-email": "testuser@example.com",
+            "0-preferred_name": "John",
+            "sign_up_wizard-current_step": "0",
+        }
 
-#         form_two = {
-#             "1-verification_code": "123456",
-#             "sign_up_wizard-current_step": "1",
-#         }
+        form_two = {
+            "1-verification_code": "123456",
+            "sign_up_wizard-current_step": "1",
+        }
 
-#         form_three = {
-#             "2-username": "john",
-#             "2-password": "password",
-#             "2-password_confirm": "password",
-#             "sign_up_wizard-current_step": "2",
-#         }
+        form_three = {
+            "2-username": "john",
+            "2-password": "password",
+            "2-password_confirm": "password",
+            "sign_up_wizard-current_step": "2",
+        }
 
-#         SIGN_UP_STEPS_DATA = [form_one, form_two, form_three]
+        SIGN_UP_STEPS_DATA = [form_one, form_two, form_three]
 
-#         for data in SIGN_UP_STEPS_DATA:
-#             response = self.client.post(self.url, data)
+        for data in SIGN_UP_STEPS_DATA:
+            response = self.client.post(self.url, data)
 
-#         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-#     def test_get_context_data_step_1(self):
-#         form_one = {
-#             "0-full_name": "John Doe",
-#             "0-email": "testuser@example.com",
-#             "0-preferred_name": "John",
-#             "sign_up_wizard-current_step": "0",
-#         }
+    def test_get_context_data_step_1(self):
+        form_one = {
+            "0-full_name": "John Doe",
+            "0-email": "testuser@example.com",
+            "0-preferred_name": "John",
+            "sign_up_wizard-current_step": "0",
+        }
 
-#         response = self.client.post(self.url, form_one)
-#         initial_dict = response.context_data.get("view").initial_dict
-#         initial_dict_data_form_one = initial_dict.get("1")
+        response = self.client.post(self.url, form_one)
+        initial_dict = response.context_data.get("view").initial_dict
+        initial_dict_data_form_one = initial_dict.get("1")
 
-#         self.assertEqual(response.status_code, 200)
-#         self.assertIsNotNone(initial_dict_data_form_one.get(SIGN_UP_REQUEST_ID))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(initial_dict_data_form_one.get(SIGN_UP_REQUEST_ID))
 
 
 class SignInViewTest(TestCase):

--- a/security/tests/test_views.py
+++ b/security/tests/test_views.py
@@ -2,7 +2,6 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth.hashers import make_password
 
-from security.constants import SIGN_UP_REQUEST_ID
 from .factories import UserFactory
 
 
@@ -40,9 +39,10 @@ class SignUpViewTest(TestCase):
         for data in SIGN_UP_STEPS_DATA:
             response = self.client.post(self.url, data)
 
-        self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("security/sign_up/sign_up.html", response.template_name)
 
-    def test_get_context_data_step_1(self):
+    def test_process_step_0(self):
         form_one = {
             "0-full_name": "John Doe",
             "0-email": "testuser@example.com",
@@ -51,11 +51,30 @@ class SignUpViewTest(TestCase):
         }
 
         response = self.client.post(self.url, form_one)
-        initial_dict = response.context_data.get("view").initial_dict
-        initial_dict_data_form_one = initial_dict.get("1")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIsNotNone(initial_dict_data_form_one.get(SIGN_UP_REQUEST_ID))
+        self.assertIsNotNone(response.client.session.get("verification_code"))
+
+    def test_process_step_1(self):
+        form_one = {
+            "0-full_name": "John Doe",
+            "0-email": "testuser@example.com",
+            "0-preferred_name": "John",
+            "sign_up_wizard-current_step": "0",
+        }
+
+        response = self.client.post(self.url, form_one)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("security/sign_up/sign_up.html", response.template_name)
+
+        form_two = {
+            "1-verification_code": "123456",
+            "sign_up_wizard-current_step": "1",
+        }
+
+        response = self.client.post(self.url, form_two)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("security/sign_up/sign_up.html", response.template_name)
 
 
 class SignInViewTest(TestCase):


### PR DESCRIPTION
We need to temporarily disable the tests for the signup page. With this PR, we enable them and modify them according to the recent changes.