### PR TITLE
Added pagination to Challenges list page

### DIFF
--- a/product_management/templates/product_management/challenges.html
+++ b/product_management/templates/product_management/challenges.html
@@ -134,5 +134,26 @@
       {% endfor %}
     </ul>
   </div>
+
+  <!-- Pagination -->
+  <div class="flex mx-auto gap-x-2 mt-10">
+
+      {% if page_obj.has_previous() %}
+      <div class=" flex items-center justify-center w-8 h-8 text-md hover:text-blue-400"><a href="?page={{ page_obj.previous_page_number() }}">&laquo;</a></div>
+      {% endif %}
+
+      {% for i in paginator.page_range %}
+        {% if page_obj.number == i %}
+          <div class=" flex items-center justify-center w-8 h-8  text-md bg-blue-400 rounded-md text-white">{{ i }}</div>
+        {% else %}
+          <div class=" flex items-center justify-center w-8 h-8 text-md hover:text-blue-400"><a href="?page={{ i }}">{{ i }}</a></div>
+        {% endif %}
+      {% endfor %}
+
+      {% if page_obj.has_next() %}
+      <div class=" flex items-center justify-center w-8 h-8 text-md hover:text-blue-400"><a href="?page={{ page_obj.next_page_number() }}">&raquo;</a></div>
+    {% endif %}
+  </div>
+
 </div>
 {% endblock %}

--- a/product_management/views.py
+++ b/product_management/views.py
@@ -53,6 +53,7 @@ class ChallengeListView(ListView):
     model = Challenge
     context_object_name = "challenges"
     template_name = "product_management/challenges.html"
+    paginate_by = 8
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
- Added pagination to challenges list view
- This PR fixes issue #130 

### Changes
- `product_management/views.py`
- `product_management/templates/product_management/challenges.html`



**Observation:** Currently the challenge items dont have fixed height. It grows in height depending on the content. We need to make this a fixed height one.


### Testing
![pagination](https://github.com/OpenUnited/platform/assets/62328681/e69d4442-7cd9-4e68-af47-6d31a9fa7ee2)






@dogukanteber, do you want to me to prioritise `help wanted` issues ?
