### PR TITLE
django-debug-toolbar raises error during the development

### DIFF
--- a/openunited/settings/development.py
+++ b/openunited/settings/development.py
@@ -11,11 +11,11 @@ ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "127.0.0.1,localhost").sp
 TEMPLATES[0]["OPTIONS"]["auto_reload"] = DEBUG
 
 # Required for django-debug-toolbar
-hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
-    "127.0.0.1",
-    "10.0.2.2",
-]
+# hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+# INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
+#     "127.0.0.1",
+#     "10.0.2.2",
+# ]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_HOST = "localhost"


### PR DESCRIPTION
I was constantly facing an error caused by `django-debug-toolbar` during the development. So, I commented it out. If one wants to use it, he/she can simply uncomment the code block.