### PR TITLE
Added cookie support in Sign in page

### DIFF
--- a/openunited/settings/base.py
+++ b/openunited/settings/base.py
@@ -197,3 +197,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+SESSION_COOKIE_AGE = 30 * 24 * 60 * 60  # 30 days in seconds

--- a/security/forms.py
+++ b/security/forms.py
@@ -147,6 +147,7 @@ class SignInForm(forms.Form):
             }
         )
     )
+    remember_me = forms.BooleanField(required=False)
 
 
 class PasswordResetForm(PasswordResetForm):

--- a/security/templates/security/sign_in/sign_in_form.html
+++ b/security/templates/security/sign_in/sign_in_form.html
@@ -31,11 +31,9 @@
     </div>
 
     <div class="flex items-center justify-between">
-        <div class="checkbox__wrap">
-            <input class="checkbox__input" id="check-remember" name="rememberMe" type="checkbox">
-            <label for="check-remember" class="checkbox__label">
-                <div class="checkbox__text">Remember Me</div>
-            </label>
+        <div class="flex items-center">
+            {{ form.remember_me }}
+            <span class="text-sm ml-2">Remember me</span>
         </div>
 
         <div class="text-sm leading-6">

--- a/security/views.py
+++ b/security/views.py
@@ -100,6 +100,9 @@ class SignInView(TemplateView):
         if form.is_valid():
             username = form.cleaned_data["username"]
             password = form.cleaned_data["password"]
+            remember_me = form.cleaned_data["remember_me"]
+            if not remember_me:
+                request.session.set_expiry(0)
 
             user_obj = User.objects.get_or_none(username=username)
             if user_obj:


### PR DESCRIPTION
- Implemented "Remember me" feature in sign in page as described in issue #139 
- This PR fix the above issue

### Solution

- Set `SESSION_COOKIE_AGE` to 30 days in settings
- Added a new check box for `Remember me` in sign in page
- If user don't check `Remember me`, the session is set to expire on browser close.

### Changes
- `openunited/settings/base.py`
- `security/forms.py`
- `security/views.py`
- `security/templates/security/sign_in/sign_in_form.html`



### Testing
- `SESSION_COOKIE_AGE` is made to 1 minute for testing

**Case: User does not check `Remember Me`**

![openunited-1](https://github.com/OpenUnited/platform/assets/62328681/b88d2c9a-b8f4-4e26-8e93-de1227abd788)


**Case: User checks `Remember Me`**





![openunited-2](https://github.com/OpenUnited/platform/assets/62328681/0c90b303-ef93-4338-adf1-85c8f318e146)


