### PR TITLE
Fix the Errors in the Work Submission Flow

### DIFF
--- a/product_management/views.py
+++ b/product_management/views.py
@@ -1133,7 +1133,7 @@ class DeleteBountyClaimView(LoginRequiredMixin, DeleteView):
         self.object = self.get_object()
         instance = BountyClaim.objects.get(pk=self.object.pk)
         if instance.kind == BountyClaim.CLAIM_TYPE_IN_REVIEW:
-            instance.delete
+            instance.delete()
             messages.success(
                 request, _("The bounty claim is successfully deleted.")
             )

--- a/talent/forms.py
+++ b/talent/forms.py
@@ -188,8 +188,10 @@ class BountyDeliveryAttemptForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if self.request:
             pk = self.request.GET.get("id", None)
-            instance = BountyClaim.objects.get(id=pk)
-            self.fields["bounty_claim"].initial = instance
+            queryset = BountyClaim.objects.filter(id=pk)
+            self.fields["bounty_claim"].queryset = queryset
+            self.fields["bounty_claim"].initial = queryset.first()
+            self.fields["bounty_claim"].empty_label = None
 
     class Meta:
         model = BountyDeliveryAttempt

--- a/talent/models.py
+++ b/talent/models.py
@@ -356,7 +356,7 @@ class BountyDeliveryAttempt(TimeStampMixin):
         )
 
     def __str__(self):
-        return f"{self.person} - {self.delivery_message}"
+        return f"{self.person} - {self.get_kind_display()}"
 
 
 class Feedback(models.Model):

--- a/talent/templates/talent/bounty_claim_attempt.html
+++ b/talent/templates/talent/bounty_claim_attempt.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Work Submission{% endblock %}
+
 {% block content %}
 
 <!--

--- a/talent/views.py
+++ b/talent/views.py
@@ -403,7 +403,7 @@ class CreateBountyDeliveryAttemptView(LoginRequiredMixin, CreateView):
         return kwargs
 
     def post(self, request, *args, **kwargs):
-        form = self.form_class(request.POST, request.FILES)
+        form = self.form_class(request.POST, request.FILES, request=request)
         if form.is_valid():
             instance = form.save(commit=False)
             instance.person = request.user.person

--- a/talent/views.py
+++ b/talent/views.py
@@ -410,6 +410,10 @@ class CreateBountyDeliveryAttemptView(LoginRequiredMixin, CreateView):
             instance.kind = BountyDeliveryAttempt.SUBMISSION_TYPE_NEW
             instance.save()
 
+            bounty_claim = instance.bounty_claim
+            bounty_claim.kind = BountyClaim.CLAIM_TYPE_IN_REVIEW
+            bounty_claim.save()
+
             return HttpResponseRedirect(self.success_url)
 
         return super().post(request, *args, **kwargs)


### PR DESCRIPTION
This PR:

* doesn't allow multiple work submissions
* fixes the cancelation operation after a work is submitted
* pre-selects the `BountyClaim` when submitting a work
* adds unit tests for `CreateBountyDeliveryAttempView`